### PR TITLE
android automatic refactor obsoletelayoutparam

### DIFF
--- a/vector/src/main/res/layout/activity_vector_room.xml
+++ b/vector/src/main/res/layout/activity_vector_room.xml
@@ -1,367 +1,325 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
 
-    <RelativeLayout
-        android:id="@+id/room_action_bar"
+  <RelativeLayout android:id="@+id/room_action_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+    <!-- room header displayed when the status bar title is pressed -->
+
+    <RelativeLayout android:id="@+id/action_bar_header"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:visibility="gone">
+
+      <include layout="@layout/vector_room_header"/>
+    </RelativeLayout>
+
+    <android.support.v7.widget.Toolbar android:id="@+id/room_toolbar"
+      android:layout_alignParentTop="true"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      app:contentInsetEnd="0dp"
+      app:contentInsetStart="0dp"
+      android:background="@color/vector_green_color"
+      style="@style/VectorToolbarStyle">
+
+      <RelativeLayout android:id="@+id/action_custom_bar_header"
+        android:background="@android:color/transparent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <!-- room header displayed when the status bar title is pressed -->
-        <RelativeLayout
-            android:id="@+id/action_bar_header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone" >
-            <include layout="@layout/vector_room_header" />
-        </RelativeLayout>
+        <include layout="@layout/vector_message_action_bar_custo_layout"/>
+      </RelativeLayout>
+    </android.support.v7.widget.Toolbar>
+  </RelativeLayout>
 
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/room_toolbar"
-            android:layout_alignParentTop="true"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:contentInsetEnd="0dp"
-            app:contentInsetStart="0dp"
-            android:background="@color/vector_green_color"
-            style="@style/VectorToolbarStyle">
+  <LinearLayout android:id="@+id/room_preview_info_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@color/room_background"
+    android:layout_below="@+id/room_action_bar">
 
-            <RelativeLayout
-                android:id="@+id/action_custom_bar_header"
-                android:background="@android:color/transparent"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-                <include layout="@layout/vector_message_action_bar_custo_layout" />
-            </RelativeLayout>
-
-        </android.support.v7.widget.Toolbar>
-    </RelativeLayout>
-
-    <LinearLayout
-        android:id="@+id/room_preview_info_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:background="@color/room_background"
-        android:layout_below="@+id/room_action_bar">
-        
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="16dp">
+    <View android:layout_width="match_parent"
+      android:layout_height="16dp">
         </View>
 
-        <TextView
-            android:id="@+id/room_preview_invitation_textview"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textSize="14sp"
-            android:text="A text here"
-            android:textColor="@color/vector_text_black_color"
-            android:layout_marginLeft="20dp"
-            android:layout_marginRight="20dp" />
+    <TextView android:id="@+id/room_preview_invitation_textview"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textSize="14sp"
+      android:text="A text here"
+      android:textColor="@color/vector_text_black_color"
+      android:layout_marginLeft="20dp"
+      android:layout_marginRight="20dp"/>
 
-        <RelativeLayout
-            android:id="@+id/preview_actions_bar"
-            android:layout_width="match_parent"
-            android:layout_height="65dp"
-            android:layout_marginLeft="20dp"
-            android:layout_marginRight="20dp">
+    <RelativeLayout android:id="@+id/preview_actions_bar"
+      android:layout_width="match_parent"
+      android:layout_height="65dp"
+      android:layout_marginLeft="20dp"
+      android:layout_marginRight="20dp">
 
-            <Button
-                android:id="@+id/button_join_room"
-                android:layout_centerVertical="true"
-                android:layout_alignParentLeft="true"
-                android:layout_marginRight="16dp"
-                android:layout_width="94dp"
-                android:layout_height="36dp"
-                android:background="@color/vector_green_color"
-                android:textColor="@android:color/white"
-                android:text="@string/join_room"/>
-
-            <Button
-                android:id="@+id/button_decline"
-                android:layout_centerVertical="true"
-                android:layout_centerHorizontal="true"
-                android:layout_width="94dp"
-                android:layout_height="36dp"
-                android:textColor="@color/vector_fuchsia_color"
-                android:background="@android:color/white"
-                android:text="@string/cancel"/>
-        </RelativeLayout>
-
-        <TextView
-            android:id="@+id/room_preview_subinvitation_textview"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="20dp"
-            android:layout_marginRight="20dp"
-            android:textSize="14sp"
-            android:text=""
-            android:textColor="@color/vector_silver_color"/>
-
-    </LinearLayout>
-
-    <im.vector.view.VectorPendingCallView
-        android:id="@+id/room_pending_call_view"
-        android:layout_below="@+id/room_preview_info_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"/>
-
-    <im.vector.view.VectorOngoingConferenceCallView
-        android:id="@+id/room_ongoing_conference_call_view"
-        android:layout_below="@+id/room_pending_call_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"/>
-
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_alignParentBottom="true"
-        android:layout_below="@+id/room_ongoing_conference_call_view">
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/room_background"
-            android:paddingTop="0dp"
-            android:paddingBottom="0dp">
-
-            <ImageView
-                android:id="@+id/search_background_imageview"
-                android:background="#FFFFFFFF"
-                android:layout_height="match_parent"
-                android:layout_width="match_parent"
-                android:layout_alignParentTop="true"
-                android:layout_alignParentLeft="true"
-                android:src="@drawable/vector_search_bg"
-                android:visibility="gone" />
-
-            <TextView
-                android:id="@+id/search_no_result_textview"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/search_no_results"
-                android:textStyle="bold"
-                android:textSize="17sp"
-                android:visibility="gone" />
-
-            <RelativeLayout
-                android:id="@+id/room_bottom_layout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="16dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                android:layout_alignParentBottom="true">
-
-                <RelativeLayout
-                    android:id="@+id/room_self_avatar_container"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content">
-
-                    <include layout="@layout/vector_room_round_avatar"
-                        android:layout_width="40dp"
-                        android:layout_height="40dp"
-                        android:layout_centerVertical="true"
-                        android:id="@+id/room_self_avatar"/>
-                </RelativeLayout>
-
-                <LinearLayout
-                    android:id="@+id/room_sending_message_layout"
-                    android:layout_alignParentRight="true"
-                    android:layout_toRightOf="@id/room_self_avatar_container"
-                    android:layout_centerInParent="true"
-                    android:layout_width="wrap_content"
-                    android:minHeight="24dp"
-                    android:layout_height="wrap_content">
-
-                    <RelativeLayout
-                        android:layout_width="20dp"
-                        android:layout_height="match_parent">
-
-                        <ImageView
-                            android:id="@+id/room_encrypted_image_view"
-                            android:layout_width="16dp"
-                            android:layout_height="16dp"
-                            android:layout_centerInParent="true"
-                            android:src="@drawable/e2e_verified"/>
-
-                    </RelativeLayout>
-
-                    <EditText
-                        android:layout_width="0dp"
-                        android:layout_weight="1"
-                        android:layout_height="wrap_content"
-                        android:inputType="textCapSentences|textMultiLine"
-                        android:textSize="14sp"
-                        android:hint="@string/room_message_placeholder"
-                        android:id="@+id/editText_messageBox"
-                        android:layout_centerVertical="true"
-                        android:theme="@style/SearchesAppTheme"
-                        android:background="@android:color/transparent"
-                        android:textCursorDrawable="@drawable/searches_cursor_background"
-                        android:textColorHint="@color/vector_0_54_black_color"/>
-
-                    <View
-                        android:id="@+id/room_button_margin_left"
-                        android:layout_width="6dp"
-                        android:layout_height="match_parent" />
-
-                    <RelativeLayout
-                        android:id="@+id/room_send_layout"
-                        android:layout_width="37dp"
-                        android:layout_height="match_parent"
-                        android:contentDescription="@string/send">
-
-                        <ImageView
-                            android:id="@+id/room_send_image_view"
-                            android:layout_width="24dp"
-                            android:layout_height="24dp"
-                            android:layout_centerInParent="true"
-                            android:src="@drawable/ic_material_file"/>
-
-                    </RelativeLayout>
-
-                    <RelativeLayout
-                        android:id="@+id/room_start_call_layout"
-                        android:layout_width="37dp"
-                        android:layout_height="match_parent"
-                        android:visibility="gone"
-                        android:contentDescription="@string/call_connecting">
-
-                        <ImageView
-                            android:id="@+id/room_start_call_image_view"
-                            android:layout_width="24dp"
-                            android:layout_height="match_parent"
-                            android:layout_centerInParent="true"
-                            android:src="@drawable/voice_call_start_green"/>
-                    </RelativeLayout>
-
-                    <RelativeLayout
-                        android:id="@+id/room_end_call_layout"
-                        android:layout_width="37dp"
-                        android:layout_height="match_parent"
-                        android:visibility="gone"
-                        android:contentDescription="@string/call_ended">
-
-                        <ImageView
-                            android:id="@+id/room_end_call_image_view"
-                            android:layout_width="24dp"
-                            android:layout_height="24dp"
-                            android:layout_centerVertical="true"
-                            android:src="@drawable/voice_call_end_fushia"/>
-                    </RelativeLayout>
-
-                    <View
-                        android:id="@+id/room_button_margin_right"
-                        android:layout_width="10dp"
-                        android:layout_height="match_parent" />
-                </LinearLayout>
-
-                <TextView
-                    android:id="@+id/room_cannot_post_textview"
-                    android:layout_centerVertical="true"
-                    android:layout_marginLeft="16dp"
-                    android:layout_marginRight="16dp"
-                    android:layout_alignParentRight="true"
-                    android:layout_toRightOf="@id/room_self_avatar_container"
-                    android:text="@string/room_do_not_have_permission_to_post"
-                    android:textSize="14sp"
-                    android:textColor="@color/vector_text_black_color"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone" />
-            </RelativeLayout>
-
-            <View
-                android:id="@+id/bottom_separator"
-                android:layout_width="fill_parent"
-                android:layout_height="1dp"
-                android:layout_alignParentLeft="true"
-                android:layout_above="@id/room_bottom_layout"
-                android:background="@color/vector_light_gray_color" />
-
-            <RelativeLayout
-                android:id="@+id/room_notifications_area"
-                android:layout_width="fill_parent"
-                android:layout_height="42dp"
-                android:layout_alignParentLeft="true"
-                android:layout_above="@id/bottom_separator"
-                android:visibility="invisible">
-
-                <ImageView
-                    android:id="@+id/room_notification_icon"
-                    android:layout_marginLeft="25dp"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_centerVertical="true"
-                    android:src="@drawable/vector_typing"/>
-
-                <TextView
-                    android:id="@+id/room_notification_message"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:layout_marginLeft="73dp"
-                    android:layout_marginRight="13dp"
-                    android:textColor="@color/vector_text_gray_color"
-                    android:text="a text here " />
-
-            </RelativeLayout>
-
-            <View
-                android:id="@+id/room_notification_separator"
-                android:layout_width="fill_parent"
-                android:layout_marginLeft="13dp"
-                android:layout_height="1dp"
-                android:layout_above="@id/room_notifications_area"
-                android:background="@color/vector_light_gray_color" />
-
-            <RelativeLayout
-                android:layout_alignParentTop="true"
-                android:layout_above="@id/room_notification_separator"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/anchor_fragment_messages"
-                android:layout_centerHorizontal="true">
-            </RelativeLayout>
-
-            <ProgressBar
-                android:id="@+id/loading_room_paginate_back_progress"
-                android:layout_height="40dp"
-                android:layout_width="match_parent"
-                android:layout_alignParentLeft="true"
-                android:visibility="gone"
-                android:indeterminate="true" />
-
-            <ProgressBar
-                android:id="@+id/loading_room_paginate_forward_progress"
-                android:layout_height="40dp"
-                android:layout_width="match_parent"
-                android:layout_alignParentLeft="true"
-                android:layout_alignBottom="@id/anchor_fragment_messages"
-                android:visibility="gone"
-                android:indeterminate="true" />
-        </RelativeLayout>
-    </RelativeLayout>
-
-    <RelativeLayout
-        android:id="@+id/main_progress_layout"
-        android:layout_alignTop="@+id/room_preview_info_layout"
+      <Button android:id="@+id/button_join_room"
+        android:layout_centerVertical="true"
         android:layout_alignParentLeft="true"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/chat_encoding_background"
-        android:visibility="gone">
-        <ProgressBar
-            android:id="@+id/medias_processing_progress"
-            android:layout_height="40dp"
-            android:layout_width="40dp"
-            android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"
-            android:indeterminate="true" />
+        android:layout_marginRight="16dp"
+        android:layout_width="94dp"
+        android:layout_height="36dp"
+        android:background="@color/vector_green_color"
+        android:textColor="@android:color/white"
+        android:text="@string/join_room"/>
+
+      <Button android:id="@+id/button_decline"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
+        android:layout_width="94dp"
+        android:layout_height="36dp"
+        android:textColor="@color/vector_fuchsia_color"
+        android:background="@android:color/white"
+        android:text="@string/cancel"/>
     </RelativeLayout>
+
+    <TextView android:id="@+id/room_preview_subinvitation_textview"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="20dp"
+      android:layout_marginRight="20dp"
+      android:textSize="14sp"
+      android:text=""
+      android:textColor="@color/vector_silver_color"/>
+  </LinearLayout>
+
+  <im.vector.view.VectorPendingCallView android:id="@+id/room_pending_call_view"
+    android:layout_below="@+id/room_preview_info_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:visibility="gone"/>
+
+  <im.vector.view.VectorOngoingConferenceCallView android:id="@+id/room_ongoing_conference_call_view"
+    android:layout_below="@+id/room_pending_call_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:visibility="gone"/>
+
+  <RelativeLayout android:layout_width="match_parent"
+    android:layout_height="0dp"
+    android:layout_alignParentBottom="true"
+    android:layout_below="@+id/room_ongoing_conference_call_view">
+
+    <RelativeLayout android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:background="@color/room_background"
+      android:paddingTop="0dp"
+      android:paddingBottom="0dp">
+
+      <ImageView android:id="@+id/search_background_imageview"
+        android:background="#FFFFFFFF"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:src="@drawable/vector_search_bg"
+        android:visibility="gone"/>
+
+      <TextView android:id="@+id/search_no_result_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/search_no_results"
+        android:textStyle="bold"
+        android:textSize="17sp"
+        android:visibility="gone"/>
+
+      <RelativeLayout android:id="@+id/room_bottom_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:layout_alignParentBottom="true">
+
+        <RelativeLayout android:id="@+id/room_self_avatar_container"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content">
+
+          <include layout="@layout/vector_room_round_avatar"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_centerVertical="true"
+            android:id="@+id/room_self_avatar"/>
+        </RelativeLayout>
+
+        <LinearLayout android:id="@+id/room_sending_message_layout"
+          android:layout_alignParentRight="true"
+          android:layout_toRightOf="@id/room_self_avatar_container"
+          android:layout_centerInParent="true"
+          android:layout_width="wrap_content"
+          android:minHeight="24dp"
+          android:layout_height="wrap_content">
+
+          <RelativeLayout android:layout_width="20dp"
+            android:layout_height="match_parent">
+
+            <ImageView android:id="@+id/room_encrypted_image_view"
+              android:layout_width="16dp"
+              android:layout_height="16dp"
+              android:layout_centerInParent="true"
+              android:src="@drawable/e2e_verified"/>
+          </RelativeLayout>
+
+          <EditText android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:inputType="textCapSentences|textMultiLine"
+            android:textSize="14sp"
+            android:hint="@string/room_message_placeholder"
+            android:id="@+id/editText_messageBox"
+            android:theme="@style/SearchesAppTheme"
+            android:background="@android:color/transparent"
+            android:textCursorDrawable="@drawable/searches_cursor_background"
+            android:textColorHint="@color/vector_0_54_black_color">
+            <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+          </EditText>
+
+          <View android:id="@+id/room_button_margin_left"
+            android:layout_width="6dp"
+            android:layout_height="match_parent"/>
+
+          <RelativeLayout android:id="@+id/room_send_layout"
+            android:layout_width="37dp"
+            android:layout_height="match_parent"
+            android:contentDescription="@string/send">
+
+            <ImageView android:id="@+id/room_send_image_view"
+              android:layout_width="24dp"
+              android:layout_height="24dp"
+              android:layout_centerInParent="true"
+              android:src="@drawable/ic_material_file"/>
+          </RelativeLayout>
+
+          <RelativeLayout android:id="@+id/room_start_call_layout"
+            android:layout_width="37dp"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            android:contentDescription="@string/call_connecting">
+
+            <ImageView android:id="@+id/room_start_call_image_view"
+              android:layout_width="24dp"
+              android:layout_height="match_parent"
+              android:layout_centerInParent="true"
+              android:src="@drawable/voice_call_start_green"/>
+          </RelativeLayout>
+
+          <RelativeLayout android:id="@+id/room_end_call_layout"
+            android:layout_width="37dp"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            android:contentDescription="@string/call_ended">
+
+            <ImageView android:id="@+id/room_end_call_image_view"
+              android:layout_width="24dp"
+              android:layout_height="24dp"
+              android:layout_centerVertical="true"
+              android:src="@drawable/voice_call_end_fushia"/>
+          </RelativeLayout>
+
+          <View android:id="@+id/room_button_margin_right"
+            android:layout_width="10dp"
+            android:layout_height="match_parent"/>
+        </LinearLayout>
+
+        <TextView android:id="@+id/room_cannot_post_textview"
+          android:layout_centerVertical="true"
+          android:layout_marginLeft="16dp"
+          android:layout_marginRight="16dp"
+          android:layout_alignParentRight="true"
+          android:layout_toRightOf="@id/room_self_avatar_container"
+          android:text="@string/room_do_not_have_permission_to_post"
+          android:textSize="14sp"
+          android:textColor="@color/vector_text_black_color"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:visibility="gone"/>
+      </RelativeLayout>
+
+      <View android:id="@+id/bottom_separator"
+        android:layout_width="fill_parent"
+        android:layout_height="1dp"
+        android:layout_alignParentLeft="true"
+        android:layout_above="@id/room_bottom_layout"
+        android:background="@color/vector_light_gray_color"/>
+
+      <RelativeLayout android:id="@+id/room_notifications_area"
+        android:layout_width="fill_parent"
+        android:layout_height="42dp"
+        android:layout_alignParentLeft="true"
+        android:layout_above="@id/bottom_separator"
+        android:visibility="invisible">
+
+        <ImageView android:id="@+id/room_notification_icon"
+          android:layout_marginLeft="25dp"
+          android:layout_width="24dp"
+          android:layout_height="24dp"
+          android:layout_centerVertical="true"
+          android:src="@drawable/vector_typing"/>
+
+        <TextView android:id="@+id/room_notification_message"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_centerVertical="true"
+          android:layout_marginLeft="73dp"
+          android:layout_marginRight="13dp"
+          android:textColor="@color/vector_text_gray_color"
+          android:text="a text here "/>
+      </RelativeLayout>
+
+      <View android:id="@+id/room_notification_separator"
+        android:layout_width="fill_parent"
+        android:layout_marginLeft="13dp"
+        android:layout_height="1dp"
+        android:layout_above="@id/room_notifications_area"
+        android:background="@color/vector_light_gray_color"/>
+
+      <RelativeLayout android:layout_alignParentTop="true"
+        android:layout_above="@id/room_notification_separator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/anchor_fragment_messages"
+        android:layout_centerHorizontal="true">
+            </RelativeLayout>
+
+      <ProgressBar android:id="@+id/loading_room_paginate_back_progress"
+        android:layout_height="40dp"
+        android:layout_width="match_parent"
+        android:layout_alignParentLeft="true"
+        android:visibility="gone"
+        android:indeterminate="true"/>
+
+      <ProgressBar android:id="@+id/loading_room_paginate_forward_progress"
+        android:layout_height="40dp"
+        android:layout_width="match_parent"
+        android:layout_alignParentLeft="true"
+        android:layout_alignBottom="@id/anchor_fragment_messages"
+        android:visibility="gone"
+        android:indeterminate="true"/>
+    </RelativeLayout>
+  </RelativeLayout>
+
+  <RelativeLayout android:id="@+id/main_progress_layout"
+    android:layout_alignTop="@+id/room_preview_info_layout"
+    android:layout_alignParentLeft="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/chat_encoding_background"
+    android:visibility="gone">
+
+    <ProgressBar android:id="@+id/medias_processing_progress"
+      android:layout_height="40dp"
+      android:layout_width="40dp"
+      android:layout_centerHorizontal="true"
+      android:layout_centerVertical="true"
+      android:indeterminate="true"/>
+  </RelativeLayout>
 </RelativeLayout>


### PR DESCRIPTION
Hi (again),

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing. I've found helpful using ```git diff -w```.

Please consider the changes and let me know if you agree with them.

Best,
Luis