### PR TITLE
fix_invite_contact_with_photo_crash

### DIFF
--- a/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
+++ b/vector/src/main/java/im/vector/adapters/ParticipantAdapterItem.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import im.vector.VectorApp;
 import im.vector.contacts.Contact;
 import im.vector.util.VectorUtils;
 
@@ -39,7 +40,6 @@ public class ParticipantAdapterItem implements java.io.Serializable {
     // displayed info
     public String mDisplayName;
     public String mAvatarUrl;
-    public Bitmap mAvatarBitmap;
 
     // user id
     public String mUserId;
@@ -92,21 +92,17 @@ public class ParticipantAdapterItem implements java.io.Serializable {
     /**
      * Constructor from a contact.
      * @param contact the contact.
-     * @param context the context.
      */
-    public ParticipantAdapterItem(Contact contact, Context context) {
+    public ParticipantAdapterItem(Contact contact) {
         mDisplayName = contact.getDisplayName();
 
         if (TextUtils.isEmpty(mDisplayName)) {
             mDisplayName = contact.getContactId();
         }
-        mAvatarBitmap = contact.getThumbnail(context);
 
         mUserId = null;
         mRoomMember = null;
-
         mContact = contact;
-
         initSearchByPatternFields();
     }
 
@@ -263,14 +259,26 @@ public class ParticipantAdapterItem implements java.io.Serializable {
     }
 
     /**
+     * Provides the avatar bitmap
+     * @return the avatar bitmap.
+     */
+    public Bitmap getAvatarBitmap() {
+        if (null != mContact) {
+            return mContact.getThumbnail(VectorApp.getInstance());
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Init an imageView with the avatar.
      * @param session the session
      * @param imageView the imageView
      */
     public void displayAvatar(MXSession session, ImageView imageView) {
         // set the
-        if (null != mAvatarBitmap) {
-            imageView.setImageBitmap(mAvatarBitmap);
+        if (null != getAvatarBitmap()) {
+            imageView.setImageBitmap(getAvatarBitmap());
         } else {
             if ((null != mUserId) && (android.util.Patterns.EMAIL_ADDRESS.matcher(mUserId).matches()) || !mIsValid) {
                 imageView.setImageBitmap(VectorUtils.getAvatar(imageView.getContext(), VectorUtils.getAvatarColor(mUserId), "@@", true));

--- a/vector/src/main/java/im/vector/adapters/VectorParticipantsAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorParticipantsAdapter.java
@@ -287,7 +287,7 @@ public class VectorParticipantsAdapter extends BaseExpandableListAdapter {
                         dummyContact.addEmailAdress(email);
                         dummyContact.setThumbnailUri(contact.getThumbnailUri());
 
-                        ParticipantAdapterItem participant = new ParticipantAdapterItem(dummyContact, mContext);
+                        ParticipantAdapterItem participant = new ParticipantAdapterItem(dummyContact);
 
                         Contact.MXID mxid = PIDsRetriever.getIntance().getMXID(email);
 

--- a/vector/src/main/java/im/vector/adapters/VectorRoomDetailsMembersAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorRoomDetailsMembersAdapter.java
@@ -687,8 +687,8 @@ public class VectorRoomDetailsMembersAdapter extends BaseExpandableListAdapter {
         }
 
         // 1 - display member avatar
-        if (null != participant.mAvatarBitmap) {
-            viewHolder.mMemberAvatarImageView.setImageBitmap(participant.mAvatarBitmap);
+        if (null != participant.getAvatarBitmap()) {
+            viewHolder.mMemberAvatarImageView.setImageBitmap(participant.getAvatarBitmap());
         } else {
             if (TextUtils.isEmpty(participant.mUserId)) {
                 VectorUtils.loadUserAvatar(mContext, mSession, viewHolder.mMemberAvatarImageView, participant.mAvatarUrl, participant.mDisplayName, participant.mDisplayName);

--- a/vector/src/main/java/im/vector/contacts/Contact.java
+++ b/vector/src/main/java/im/vector/contacts/Contact.java
@@ -69,7 +69,7 @@ public class Contact implements java.io.Serializable {
     // the thumbnail uri
     private String mThumbnailUri;
     // the thumbnail image
-    private Bitmap mThumbnail;
+    private transient Bitmap mThumbnail;
 
     // phone numbers list
     private final ArrayList<String> mPhoneNumbers = new ArrayList<>();


### PR DESCRIPTION
Invite a contact with a thumbmail used to crash the application.

It was triggered because the Contact and ParticipantItem classes tried to serialize a bitmap.