### PR TITLE
Increase height of the message text box tappable area to full height

### DIFF
--- a/vector/src/main/res/layout/activity_vector_room.xml
+++ b/vector/src/main/res/layout/activity_vector_room.xml
@@ -1,5 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -153,14 +154,18 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                android:layout_alignParentBottom="true">
+                android:layout_marginTop="0dp"
+                android:layout_marginBottom="0dp"
+                android:layout_alignParentBottom="true"
+                android:paddingBottom="0dp"
+                android:paddingTop="0dp">
 
                 <RelativeLayout
                     android:id="@+id/room_self_avatar_container"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginTop="8dp">
 
                     <include layout="@layout/vector_room_round_avatar"
                         android:layout_width="40dp"
@@ -173,10 +178,11 @@
                     android:id="@+id/room_sending_message_layout"
                     android:layout_alignParentRight="true"
                     android:layout_toRightOf="@id/room_self_avatar_container"
-                    android:layout_centerInParent="true"
                     android:layout_width="wrap_content"
                     android:minHeight="24dp"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    tools:layout_height="wrap_content"
+                    android:layout_centerInParent="true">
 
                     <RelativeLayout
                         android:layout_width="20dp"
@@ -203,7 +209,11 @@
                         android:theme="@style/SearchesAppTheme"
                         android:background="@android:color/transparent"
                         android:textCursorDrawable="@drawable/searches_cursor_background"
-                        android:textColorHint="@color/vector_0_54_black_color"/>
+                        android:textColorHint="@color/vector_0_54_black_color"
+                        android:layout_marginBottom="0dp"
+                        android:layout_marginTop="0dp"
+                        android:paddingTop="20dp"
+                        android:paddingBottom="20dp" />
 
                     <View
                         android:id="@+id/room_button_margin_left"


### PR DESCRIPTION
The message text box in the app currently only covers about a third vertically of the bar at the bottom of the screen, which makes it easy to miss and not activate it when you tap it. This changes the height so the text box covers the entire height of the bar, which makes it activate when you tap anywhere (vertically, not horizontally) inside the bottom bar.

This change doesn't affect the way the text box behaves (cosmetically or otherwise) at all, as far as I have tested it. The change is not a visual change, it only increases the height of the tappable area of the textbox.