### PR TITLE
improve_gcm_re_registration

### DIFF
--- a/vector/src/app/java/im/vector/gcm/GCMHelper.java
+++ b/vector/src/app/java/im/vector/gcm/GCMHelper.java
@@ -1,6 +1,7 @@
 /* 
  * Copyright 2014 OpenMarket Ltd
- * 
+ * Copyright 2017 Vector Creations Ltd
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +17,8 @@
 package im.vector.gcm;
 
 import android.content.Context;
+import android.widget.ExpandableListView;
+
 import org.matrix.androidsdk.util.Log;
 
 import com.google.android.gms.gcm.GoogleCloudMessaging;
@@ -29,6 +32,7 @@ public class GCMHelper {
 
     /**
      * Retrieves the GCM registration token.
+     *
      * @param appContext the application context
      * @return the registration token.
      */
@@ -37,18 +41,29 @@ public class GCMHelper {
 
         try {
             Log.d(LOG_TAG, "Getting the GCM Registration Token");
-
-            InstanceID instanceID = InstanceID.getInstance(appContext);
-
-            registrationToken = instanceID.getToken(appContext.getString(R.string.gcm_defaultSenderId),
+            registrationToken = InstanceID.getInstance(appContext).getToken(appContext.getString(R.string.gcm_defaultSenderId),
                     GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
 
             Log.d(LOG_TAG, "GCM Registration Token: " + registrationToken);
         } catch (Exception e) {
-            Log.e(LOG_TAG, "getRegistrationToken failed with exception : " + e.getLocalizedMessage());
+            Log.e(LOG_TAG, "getRegistrationToken failed with exception : " + e.getMessage());
             registrationToken = null;
         }
 
         return registrationToken;
+    }
+
+    /**
+     * Clear the registration token.
+     *
+     * @param appContext the application context
+     */
+    public static void clearRegistrationToken(Context appContext) {
+        try {
+            InstanceID.getInstance(appContext).deleteToken(appContext.getString(R.string.gcm_defaultSenderId), GoogleCloudMessaging.INSTANCE_ID_SCOPE);
+            InstanceID.getInstance(appContext).deleteInstanceID();
+        } catch (Exception e) {
+            Log.e(LOG_TAG, "clearRegistrationToken failed with exception : " + e.getMessage());
+        }
     }
 }

--- a/vector/src/app/java/im/vector/gcm/MatrixInstanceIDListenerService.java
+++ b/vector/src/app/java/im/vector/gcm/MatrixInstanceIDListenerService.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2017 Vector Creations Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +35,6 @@ public class MatrixInstanceIDListenerService extends InstanceIDListenerService {
     @Override
     public void onTokenRefresh() {
         Log.d(LOG_TAG, "onTokenRefresh");
-        Matrix.getInstance(this).getSharedGCMRegistrationManager().resetGCMRegistration();
+        Matrix.getInstance(this).getSharedGCMRegistrationManager().resetGCMRegistration(true);
     }
 }

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 OpenMarket Ltd
+ * Copyright 2017 Vector Creations Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +23,8 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.os.Looper;
 import android.text.TextUtils;
+
+import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.util.Log;
 
 import org.matrix.androidsdk.HomeserverConnectionConfig;
@@ -616,7 +619,7 @@ public class Matrix {
      * Any opened activity is closed and the application switches to the splash screen.
      * @param context the context
      */
-    public void reloadSessions(Context context) {
+    public void reloadSessions(final Context context) {
         ArrayList<MXSession> sessions = getMXSessions(context);
 
         for(MXSession session : sessions) {
@@ -635,13 +638,18 @@ public class Matrix {
             }
         }
 
-        Intent intent = new Intent(context.getApplicationContext(), SplashActivity.class);
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        context.getApplicationContext().startActivity(intent);
+        // clear GCM token before launching the splash screen
+        Matrix.getInstance(context).getSharedGCMRegistrationManager().clearGCMData(new SimpleApiCallback<Void>() {
+            @Override
+            public void onSuccess(final Void anything) {
+                Intent intent = new Intent(context.getApplicationContext(), SplashActivity.class);
+                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                context.getApplicationContext().startActivity(intent);
 
-        if (null != VectorApp.getCurrentActivity()) {
-            VectorApp.getCurrentActivity().finish();
-        }
+                if (null != VectorApp.getCurrentActivity()) {
+                    VectorApp.getCurrentActivity().finish();
+                }
+            }});
     }
 
     /**

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -60,6 +60,7 @@ import org.matrix.androidsdk.data.RoomSummary;
 import org.matrix.androidsdk.data.store.IMXStore;
 import org.matrix.androidsdk.db.MXMediasCache;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
+import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.MatrixError;
 import org.matrix.androidsdk.rest.model.PowerLevels;
@@ -77,6 +78,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.crypto.Mac;
 
 import im.vector.Matrix;
 import im.vector.MyPresenceManager;
@@ -305,9 +308,9 @@ public class CommonActivityUtils {
      * @param activity the caller activity
      * @param goToLoginPage true to jump to the login page
      */
-    public static void logout(Activity activity, boolean goToLoginPage) {
+    public static void logout(final Activity activity, boolean goToLoginPage) {
         // if no activity is provided, use the application context instead.
-        Context context = (null == activity) ? VectorApp.getInstance().getApplicationContext() : activity;
+        final Context context = (null == activity) ? VectorApp.getInstance().getApplicationContext() : activity;
 
         EventStreamService.removeNotification();
         stopEventStream(context);
@@ -344,7 +347,7 @@ public class CommonActivityUtils {
         }
 
         // reset the GCM
-        Matrix.getInstance(context).getSharedGCMRegistrationManager().reset();
+        Matrix.getInstance(context).getSharedGCMRegistrationManager().resetGCMRegistration(false);
 
         // clear credentials
         Matrix.getInstance(context).clearSessions(context, true);

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2017 Vector Creations Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +23,9 @@ import android.content.pm.PackageInfo;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.text.TextUtils;
+
+import org.matrix.androidsdk.MXDataHandler;
+import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.util.Log;
 
 import org.matrix.androidsdk.MXSession;
@@ -162,24 +166,6 @@ public final class GcmRegistrationManager {
     }
 
     /**
-     * reset the Registration
-     */
-    public void reset() {
-        Log.d(LOG_TAG, "Reset the registration");
-
-        // unregister
-        unregister(null);
-
-        // remove the customized keys
-        getGcmSharedPreferences().
-                edit().
-                remove(PREFS_SENDER_ID_KEY).
-                remove(PREFS_PUSHER_URL_KEY).
-                remove(PREFS_PUSHER_FILE_TAG_KEY).
-                commit();
-    }
-
-    /**
      * Check if the GCM registration has been broken with a new token ID.
      * The GCM could have cleared it (onTokenRefresh).
      */
@@ -306,9 +292,10 @@ public final class GcmRegistrationManager {
     }
 
     /**
-     * Reset the GCM registration (happen when the registration token has been updated).
+     * Reset the GCM registration.
+     * @param register set to true to trigger a fresh registration.
      */
-    public void resetGCMRegistration() {
+    public void resetGCMRegistration(final boolean register) {
         Log.d(LOG_TAG, "resetGCMRegistration");
 
         if (RegistrationState.SERVER_REGISTERED == mRegistrationState) {
@@ -326,7 +313,7 @@ public final class GcmRegistrationManager {
                 @Override
                 public void onThirdPartyUnregistered() {
                     Log.d(LOG_TAG, "resetGCMRegistration : unregistration is done --> start the registration process");
-                    resetGCMRegistration();
+                    resetGCMRegistration(register);
                 }
 
                 @Override
@@ -334,13 +321,19 @@ public final class GcmRegistrationManager {
                     Log.d(LOG_TAG, "resetGCMRegistration : unregistration failed.");
                 }
             });
-
         } else {
-            Log.d(LOG_TAG, "resetGCMRegistration : make a full registration process.");
-
-            setStoredRegistrationToken(null);
-            mRegistrationState = RegistrationState.UNREGISTRATED;
-            register(null);
+            Log.d(LOG_TAG, "resetGCMRegistration : Clear the GCM data");
+            clearGCMData(new SimpleApiCallback<Void>() {
+                @Override
+                public void onSuccess(Void info) {
+                    if (register) {
+                        Log.d(LOG_TAG, "resetGCMRegistration : make a full registration process.");
+                        register(null);
+                    } else {
+                        Log.d(LOG_TAG, "resetGCMRegistration : Ready to register.");
+                    }
+                }
+            });
         }
     }
 
@@ -1003,6 +996,30 @@ public final class GcmRegistrationManager {
         getGcmSharedPreferences().edit()
                 .putString(PREFS_PUSHER_REGISTRATION_TOKEN_KEY, registrationToken)
                 .apply();
+    }
+
+    /**
+     * Clear the GCM data
+     */
+    public void clearGCMData(final ApiCallback callback) {
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                getGcmSharedPreferences().edit().clear().apply();
+                mRegistrationToken = null;
+                mRegistrationState = RegistrationState.UNREGISTRATED;
+                GCMHelper.clearRegistrationToken(mContext);
+                return null;
+            }
+
+            @Override
+            protected void onPostExecute(Void nothing) {
+                if (null != callback) {
+                    callback.onSuccess(null);
+                }
+
+            }
+        }.execute();
     }
 
     //================================================================================


### PR DESCRIPTION
Add a new GCM registration when the user logs out or triggers a clear cache.

Several users reported that their devices don't receive anymore pushes.
To ensure it is not a client side issue, i've added a full GCM registration when
-> the application is logged out 
-> the application cache is cleared.