### PR TITLE
increase_edit_text_clickable_area

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -732,8 +732,20 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
         mNotificationTextView = (TextView) mNotificationsArea.findViewById(R.id.room_notification_message);
 
         mCanNotPostTextView = findViewById(R.id.room_cannot_post_textview);
-        mStartCallLayout = findViewById(R.id.room_start_call_layout);
 
+        // increase the clickable area to open the keyboard.
+        // when there is no text, it is quite small and some user thought the edition was disabled.
+        findViewById(R.id.room_sending_message_layout).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mEditText.requestFocus()) {
+                    InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                    imm.showSoftInput(mEditText, InputMethodManager.SHOW_IMPLICIT);
+                }
+            }
+        });
+
+        mStartCallLayout = findViewById(R.id.room_start_call_layout);
         mStartCallLayout.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/vector/src/main/res/layout/activity_vector_room.xml
+++ b/vector/src/main/res/layout/activity_vector_room.xml
@@ -153,12 +153,12 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
                 android:layout_alignParentBottom="true">
 
                 <RelativeLayout
                     android:id="@+id/room_self_avatar_container"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content">
 
@@ -175,7 +175,7 @@
                     android:layout_toRightOf="@id/room_self_avatar_container"
                     android:layout_centerInParent="true"
                     android:layout_width="wrap_content"
-                    android:minHeight="24dp"
+                    android:minHeight="56dp"
                     android:layout_height="wrap_content">
 
                     <RelativeLayout
@@ -195,6 +195,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
                         android:inputType="textCapSentences|textMultiLine"
                         android:textSize="14sp"
                         android:hint="@string/room_message_placeholder"


### PR DESCRIPTION
fix https://github.com/vector-im/riot-android/issues/941
Usability: The compose window activation area is deceptively small