### PR TITLE
increase_room_button_clickable_area

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -779,6 +779,21 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
                                            }
         );
 
+        findViewById(R.id.room_button_margin_right).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // extend the right side of right button
+                // to avoid clicking in the void
+                if (mStopCallLayout.getVisibility() == View.VISIBLE) {
+                    mStopCallLayout.performClick();
+                } else if (mStartCallLayout.getVisibility() == View.VISIBLE) {
+                    mStartCallLayout.performClick();
+                } else if (mSendButtonLayout.getVisibility() == View.VISIBLE) {
+                    mSendButtonLayout.performClick();
+                }
+            }
+        });
+
         mMyUserId = mSession.getCredentials().userId;
 
         CommonActivityUtils.resumeEventStream(this);


### PR DESCRIPTION
Should fix https://github.com/vector-im/riot-android/issues/989
it sometimes takes several presses of the send button to get the message out

The right buttons margin is now clickable. The margin extends the right most button.