### PR TITLE
fix_call_resume_resume

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorCallViewActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorCallViewActivity.java
@@ -387,6 +387,7 @@ public class VectorCallViewActivity extends Activity implements SensorEventListe
             // active call must be
             return
                     (state.equals(IMXCall.CALL_STATE_RINGING) && !mCall.isIncoming()) ||
+                            state.equals(IMXCall.CALL_STATE_WAIT_LOCAL_MEDIA) ||
                             state.equals(IMXCall.CALL_STATE_CONNECTING) ||
                             state.equals(IMXCall.CALL_STATE_CONNECTED) ||
                             state.equals(IMXCall.CALL_STATE_CREATE_ANSWER);


### PR DESCRIPTION
fix https://github.com/vector-im/riot-android/issues/1013 : Voip: call canceled when switching from call layout and pending call view