### PR TITLE
ux_rework_simplify_sticky

### DIFF
--- a/vector/src/main/java/im/vector/util/StickySectionHelper.java
+++ b/vector/src/main/java/im/vector/util/StickySectionHelper.java
@@ -173,12 +173,11 @@ public class StickySectionHelper extends RecyclerView.OnScrollListener implement
 
         Log.i(LOG_TAG, "computeSectionViewsCoordinates");
         if (!sectionViews.isEmpty()) {
-
             // Compute header
             for (int i = 0; i < sectionViews.size(); i++) {
-                SectionView previous = i > 0 ? sectionViews.get(i - 1).second : null;
+                //SectionView previous = i > 0 ? sectionViews.get(i - 1).second : null;
                 SectionView current = sectionViews.get(i).second;
-                SectionView next = i + 1 < sectionViews.size() ? sectionViews.get(i + 1).second : null;
+                //SectionView next = i + 1 < sectionViews.size() ? sectionViews.get(i + 1).second : null;
 
                 current.measure(View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED), View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
                 int sectionHeight = current.getStickyHeaderHeight();
@@ -195,9 +194,9 @@ public class StickySectionHelper extends RecyclerView.OnScrollListener implement
 
             // Compute footer
             for (int i = sectionViews.size() - 1; i >= 0; i--) {
-                SectionView previous = i > 0 ? sectionViews.get(i - 1).second : null;
+                //SectionView previous = i > 0 ? sectionViews.get(i - 1).second : null;
                 SectionView current = sectionViews.get(i).second;
-                SectionView next = i + 1 < sectionViews.size() ? sectionViews.get(i + 1).second : null;
+                //SectionView next = i + 1 < sectionViews.size() ? sectionViews.get(i + 1).second : null;
 
                 current.measure(View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED), View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
                 int sectionheight = current.getStickyHeaderHeight();
@@ -216,11 +215,16 @@ public class StickySectionHelper extends RecyclerView.OnScrollListener implement
 
     private void updateStickySection(int dy) {
         Log.e(LOG_TAG, "updateStickySection " + dy);
+
+        // header is out of screen, check if header or footer
+        int firstVisiPos = mLayoutManager.findFirstVisibleItemPosition();
+        int lastVisiPos = mLayoutManager.findLastVisibleItemPosition();
+
+
         for (int i = mSectionViews.size() - 1; i >= 0; i--) {
             SectionView previous = i > 0 ? mSectionViews.get(i - 1).second : null;
             int currentPos = mSectionViews.get(i).first;
             SectionView current = mSectionViews.get(i).second;
-            SectionView next = i + 1 < mSectionViews.size() ? mSectionViews.get(i + 1).second : null;
 
             RecyclerView.ViewHolder holder = mRecyclerView.findViewHolderForLayoutPosition(currentPos);
             Log.e(LOG_TAG, "updateStickySection holder for " + current.getSection().getTitle() + " is " + holder);
@@ -231,16 +235,15 @@ public class StickySectionHelper extends RecyclerView.OnScrollListener implement
                     previous.onFoldSubView(current, dy);
                 }
             } else {
-                // header is out of screen, check if header or footer
-                int firstVisiPos = mLayoutManager.findFirstVisibleItemPosition();
-                int lastVisiPos = mLayoutManager.findLastVisibleItemPosition();
                 if (currentPos < firstVisiPos) {
                     current.updatePosition(current.getHeaderTop());
                 } else if (currentPos > lastVisiPos) {
                     current.updatePosition(current.getFooterTop());
                 }
             }
-            current.requestLayout();
+
+            // updatePosition already calls requestLayout
+            //current.requestLayout();
         }
     }
 

--- a/vector/src/main/java/im/vector/view/SectionView.java
+++ b/vector/src/main/java/im/vector/view/SectionView.java
@@ -116,21 +116,30 @@ public class SectionView extends RelativeLayout {
      * @param dy
      */
     public void onFoldSubView(final SectionView nextSection, int dy) {
+        // nothing to do
+        if (0 == dy) {
+            return;
+        }
+
         Log.d(LOG_TAG, "onFoldSubView dy " + dy);
         if (mSubView != null) {
             if (nextSection.getTop() <= getBottom()) {
                 int translation;
-                if (dy > 0) {
-                    translation = Math.max(nextSection.getTop() - getBottom(), 0);
-                    mSubView.setTranslationY(translation);
-                } else if (dy < 0) {
-                    translation = Math.min(nextSection.getTop() - getBottom(), 0);
+
+                if (-(nextSection.getTop() - getBottom()) > mSubView.getMeasuredHeight()) {
+                    translation = 0;
+                } else {
+                    if (dy > 0) {
+                        translation = Math.max(nextSection.getTop() - getBottom(), 0);
+                    } else {
+                        translation = Math.min(nextSection.getTop() - getBottom(), 0);
+                    }
+                }
+
+                if (mSubView.getTranslationY() != translation) {
                     mSubView.setTranslationY(translation);
                 }
 
-                if (-(nextSection.getTop() - getBottom()) > mSubView.getMeasuredHeight()) {
-                    mSubView.setTranslationY(0);
-                }
             } else if (mSubView.getTranslationY() < 0) {
                 mSubView.setTranslationY(0);
             }
@@ -225,11 +234,13 @@ public class SectionView extends RelativeLayout {
         int newTranslationY = Math.max(mHeaderTop, topMargin);
         newTranslationY = Math.min(newTranslationY, mFooterTop);
 
-        Log.e(LOG_TAG, "sectionview " + mSection.getTitle() + " updatePosition translation y " + newTranslationY);
+        if (getTranslationY() != newTranslationY) {
+            Log.e(LOG_TAG, "sectionview " + mSection.getTitle() + " updatePosition translation y " + newTranslationY);
 
-        setTranslationY(newTranslationY);
-        requestLayout();
-        invalidate();
+            setTranslationY(newTranslationY);
+            requestLayout();
+            invalidate();
+        }
     }
 }
 


### PR DESCRIPTION
Reduce the number of requestLayout calls

It used to trigger a loop when the list was scrolled 
updateStickySection called requestLayout (even if it was not needed) -> onLayoutChange ->  updateStickySection.

the list was laggy on some devices (there was no lag on a Samsung S6 or a nexus 6)