### PR TITLE
Add menu option to check for updates for jenkin builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,10 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 
+# Can manually override the config options for "check for updates function"
+# JENKINS_JOB_URL = "https://matrix.org/jenkins/job/VectorAndroidDevelop/"
+# JENKINS_BUILD_NUMBER = 1246
+
 # To do a signed release APK, put these variables in ~/.gradle/gradle.properties
 # RELEASE_STORE_FILE=/path/to/keystore
 # RELEASE_STORE_PASSWORD=password

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -34,12 +34,16 @@ android {
         debug {
             resValue "string", "git_revision", "\"${gitRevision()}\""
             resValue "string", "git_revision_date", "\"${gitRevisionDate()}\""
+            resValue "string", "jenkins_job_url", "\"${jenkinsJobUrl()}\""
+            resValue "integer", "jenkins_build_number", "${jenkinsBuildNumber()}"
             minifyEnabled false
         }
 
         release {
             resValue "string", "git_revision", "\"${gitRevision()}\""
             resValue "string", "git_revision_date", "\"${gitRevisionDate()}\""
+            resValue "string", "jenkins_job_url", "\"${jenkinsJobUrl()}\""
+            resValue "integer", "jenkins_build_number", "${jenkinsBuildNumber()}"
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
@@ -87,6 +91,29 @@ android {
 
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots"
+        }
+    }
+}
+
+def jenkinsBuildNumber() {
+    if (project.hasProperty("JENKINS_BUILD_NUMBER")) {
+        return JENKINS_BUILD_NUMBER
+    } else if (System.getenv("BUILD_NUMBER")) {
+        return Integer.parseInt(System.getenv("BUILD_NUMBER"))
+    } else {
+        return 0
+    }
+}
+
+def jenkinsJobUrl() {
+    if (project.hasProperty("JENKINS_JOB_URL")) {
+        return JENKINS_JOB_URL
+    } else {
+        String url = System.getenv("JOB_URL");
+        if (url == null) {
+            return ""
+        } else {
+            return url
         }
     }
 }

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -113,6 +113,7 @@ import im.vector.ga.GAHelper;
 import im.vector.receiver.VectorUniversalLinkReceiver;
 import im.vector.services.EventStreamService;
 import im.vector.util.BugReporter;
+import im.vector.util.CheckForUpdates;
 import im.vector.util.RoomUtils;
 import im.vector.util.VectorCallSoundManager;
 import im.vector.util.VectorUtils;
@@ -1539,6 +1540,13 @@ public class VectorHomeActivity extends AppCompatActivity implements SearchView.
                         break;
                     }
 
+                    case R.id.sliding_menu_check_for_update: {
+                        if (CommonActivityUtils.checkPermissions(CommonActivityUtils.REQUEST_CODE_PERMISSION_HOME_ACTIVITY, VectorHomeActivity.this)) {
+                            CheckForUpdates.checkForUpdates();
+                        }
+                        break;
+                    }
+
                     case R.id.sliding_menu_sign_out: {
                         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(VectorHomeActivity.this);
                         alertDialogBuilder.setMessage(getString(R.string.action_sign_out_confirmation));
@@ -1634,6 +1642,12 @@ public class VectorHomeActivity extends AppCompatActivity implements SearchView.
         if (null != aboutMenuItem) {
             String version = this.getString(R.string.room_sliding_menu_version) + " " + VectorUtils.getApplicationVersion(this);
             aboutMenuItem.setTitle(version);
+        }
+
+        String jenkinsJobUrl = getApplicationContext().getString(R.string.jenkins_job_url);
+        if (jenkinsJobUrl != null && !jenkinsJobUrl.isEmpty()) {
+            MenuItem checkForUpdatesMenuItem = menuNav.findItem(R.id.sliding_menu_check_for_update);
+            checkForUpdatesMenuItem.setVisible(true);
         }
 
         // init the main menu

--- a/vector/src/main/java/im/vector/util/CheckForUpdates.java
+++ b/vector/src/main/java/im/vector/util/CheckForUpdates.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2016 OpenMarket Ltd
+ * Copyright 2017 Vector Creations Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.util;
+
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.DownloadManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.net.Uri;
+import android.os.Environment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import org.json.JSONObject;
+import org.matrix.androidsdk.util.JsonUtils;
+import org.matrix.androidsdk.util.Log;
+
+import com.squareup.okhttp.Callback;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import im.vector.R;
+import im.vector.VectorApp;
+import im.vector.activity.CommonActivityUtils;
+import im.vector.adapters.AdapterUtils;
+
+
+public class CheckForUpdates {
+    private static final String LOG_TAG = "CheckForUpdates";
+
+    // the http client
+    private static final OkHttpClient mOkHttpClient = new OkHttpClient();
+
+
+    public static void checkForUpdates() {
+        final Activity currentActivity = VectorApp.getCurrentActivity();
+
+        // no current activity so cannot display an alert
+        if (null == currentActivity) {
+            return;
+        }
+
+        final Context appContext = currentActivity.getApplicationContext();
+        LayoutInflater inflater = currentActivity.getLayoutInflater();
+        View dialogLayout = inflater.inflate(R.layout.dialog_check_for_updates, null);
+
+        final AlertDialog.Builder dialog = new AlertDialog.Builder(currentActivity);
+        dialog.setTitle("Update");
+        dialog.setView(dialogLayout);
+
+        final TextView textView = (TextView) dialogLayout.findViewById(R.id.check_for_updates_text_view);
+        final ProgressBar progressBar = (ProgressBar) dialogLayout.findViewById(R.id.check_for_updates_progress_view);
+
+        dialog.setPositiveButton(R.string.send, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                // will be overridden to avoid dismissing the dialog while displaying the progress
+            }
+        });
+
+        dialog.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+            }
+        });
+
+        final AlertDialog checkForUpdatesDialog = dialog.show();
+        final int currentBuildNumber = appContext.getResources().getInteger(R.integer.jenkins_build_number);
+
+        final Button cancelButton = checkForUpdatesDialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+        final Button sendButton = checkForUpdatesDialog.getButton(AlertDialog.BUTTON_POSITIVE);
+
+        cancelButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                checkForUpdatesDialog.dismiss();
+            }
+        });
+
+        sendButton.setEnabled(false);
+
+        final String jenkinsJobUrl = appContext.getString(R.string.jenkins_job_url);
+
+        Request request = new Request.Builder()
+            .url(jenkinsJobUrl + "api/json?tree=lastSuccessfulBuild[*]")
+            .get()
+            .build();
+
+        mOkHttpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Request request, IOException e) {
+                currentActivity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        progressBar.setVisibility(View.GONE);
+                        textView.setText("Failed to check for updates");
+                    }
+                });
+            }
+
+            @Override
+            public void onResponse(final Response response) throws IOException {
+                currentActivity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        progressBar.setVisibility(View.GONE);
+
+                        if (response.code() != HttpURLConnection.HTTP_OK) {
+                            textView.setText("Failed to check for updates");
+                        }
+
+                        try {
+                            JSONObject json = new JSONObject(response.body().string());
+                            JSONObject lastBuild = json.getJSONObject("lastSuccessfulBuild");
+                            final int number = lastBuild.getInt("number");
+
+                            if (number == currentBuildNumber) {
+                                textView.setText("No new updates available.\n\nCurrent build: #" + number);
+                                return;
+                            }
+
+                            long timestamp = lastBuild.getLong("timestamp");
+                            String formatted_time = AdapterUtils.tsToString(appContext, timestamp, true);
+                            textView.setText(
+                                String.format(
+                                    "Old Build:  #%d\nNew Build:  #%d\nBuilt at:  %s\n",
+                                    currentBuildNumber, number, formatted_time
+                                )
+                            );
+
+                            final Uri apkUri = Uri.parse(
+                                    jenkinsJobUrl + "lastSuccessfulBuild/artifact/vector/build/outputs/apk/vector-app-debug.apk"
+                            );
+
+                            sendButton.setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    DownloadManager downloadManager = (DownloadManager) appContext.getSystemService(Context.DOWNLOAD_SERVICE);
+
+                                    DownloadManager.Request request = new DownloadManager.Request(apkUri);
+                                    request.setTitle("Riot Update");
+                                    request.allowScanningByMediaScanner();
+                                    request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, "vector-app-debug.apk");
+                                    request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+
+                                    downloadManager.enqueue(request);
+                                    checkForUpdatesDialog.dismiss();
+                                }
+                            });
+
+                            sendButton.setEnabled(true);
+                        } catch (Exception e) {
+                            textView.setText("Failed to check for updates");
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/vector/src/main/res/layout/dialog_check_for_updates.xml
+++ b/vector/src/main/res/layout/dialog_check_for_updates.xml
@@ -1,0 +1,33 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/check_for_updates_body_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:layout_marginTop="10dp"
+        android:orientation="vertical">
+
+        <ProgressBar
+            android:id="@+id/check_for_updates_progress_view"
+            android:layout_width="match_parent"
+            android:layout_height="20dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="10dp"
+            />
+
+        <TextView
+            android:id="@+id/check_for_updates_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="10dp"
+            android:layout_marginTop="10dp"
+            android:text="Checking for updates..." />
+    </LinearLayout>
+</FrameLayout>

--- a/vector/src/main/res/menu/vector_home_sliding_menu.xml
+++ b/vector/src/main/res/menu/vector_home_sliding_menu.xml
@@ -21,6 +21,12 @@
             android:id="@+id/sliding_menu_sign_out"
             android:icon="@drawable/ic_material_exit_to_app"
             android:title="@string/action_sign_out"/>
+
+        <item
+            android:id="@+id/sliding_menu_check_for_update"
+            android:icon="@drawable/icons_settings"
+            android:title="Check for updates"
+            android:visible="false"/>
     </group>
 
     <group android:id="@+id/app_group">


### PR DESCRIPTION
Setting `JOB_URL` and `BUILD_NUMBER` environment variables during build will enable a menu item that will check for any updates and prompt if the user wants to download them.

These enviroment variables are enabled by default for jenkins builds.

---

This is a quick hacky first attempt at doing this, and I'm not sure whether this is even something we want to do but I think it might be quite useful :)