### PR TITLE
ux_rework_fix_quick_directory_scroll

### DIFF
--- a/vector/src/main/java/im/vector/fragments/RoomsFragment.java
+++ b/vector/src/main/java/im/vector/fragments/RoomsFragment.java
@@ -368,10 +368,27 @@ public class RoomsFragment extends AbsHomeFragment implements AbsHomeFragment.On
 
             // we load public rooms 20 by 20, when the 10th one becomes visible, starts loading the next 20
             SectionView sectionView = mAdapter.getSectionViewForSectionIndex(mAdapter.getSectionsCount()-1);
-            AdapterSection section = sectionView != null ? sectionView.getSection() : null;
+            AdapterSection lastSection = sectionView != null ? sectionView.getSection() : null;
 
-            if ((section != null) && (section.getItems().size() >= 10) && mAdapter.getItemForPosition(lastVisibleItemPosition) == section.getItems().get(section.getItems().size() - 10)) {
-                forwardPaginate();
+            if (null != lastSection) {
+                // detect if the last visible item is inside another section
+                for(int i = 0; i < mAdapter.getSectionsCount()-1; i++) {
+                    SectionView prevSectionView = mAdapter.getSectionViewForSectionIndex(i);
+
+                    if ((null != prevSectionView) && (null != prevSectionView.getSection())) {
+                        lastVisibleItemPosition -= prevSectionView.getSection().getNbItems();
+
+                        // the item is in a previous section
+                        if (lastVisibleItemPosition <= 0) {
+                            return;
+                        }
+                    }
+                }
+
+                // trigger a forward paginate when there are only 10 items left
+                if ((lastSection.getNbItems() - lastVisibleItemPosition) < 10) {
+                    forwardPaginate();
+                }
             }
         }
     };


### PR DESCRIPTION
Fixed issue reported by Jean
if you scroll too fast in the room directory section, the pagination will be stopped early. It will be necessary to scroll up then scroll down to trigger again the pagination.