### PR TITLE
Fix highlighting of IRC users

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -1942,7 +1942,7 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
      * @param displayName the display name to sanitize
      * @return the sanitized display name
      */
-    private static String sanitizeDisplayname(String displayName) {
+    public static String sanitizeDisplayname(String displayName) {
         // sanity checks
         if (!TextUtils.isEmpty(displayName)) {
             final String ircPattern = " (IRC)";

--- a/vector/src/main/java/im/vector/adapters/AutoCompletedUserAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/AutoCompletedUserAdapter.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import org.matrix.androidsdk.MXSession;
 
 import im.vector.R;
+import im.vector.activity.VectorRoomActivity;
 import im.vector.util.VectorUtils;
 import im.vector.view.VectorCircularImageView;
 
@@ -207,7 +208,9 @@ public class AutoCompletedUserAdapter extends ArrayAdapter<User> {
         @Override
         public CharSequence convertResultToString(Object resultValue) {
             User user = (User) resultValue;
-            return (mIsSearchingMatrixId || mProvideMatrixIdOnly) ? user.user_id : user.displayname;
+            return (mIsSearchingMatrixId || mProvideMatrixIdOnly) ?
+                    user.user_id :
+                    VectorRoomActivity.sanitizeDisplayname(user.displayname);
         }
     }
 }


### PR DESCRIPTION
When highlighting users on IRC, `(IRC)` is appended to the highlights, whereas the normal highlight method (tapping on the username) does not have this behavior. This PR makes the two methods have the same behavior.

However, the new pop-up still does not append `:` when the textbox is empty (which I couldn't figure out how to do, but would be a nice addition).

Before (highlght using the pop-up):
![2017-06-19-003448_460x817_scrot](https://user-images.githubusercontent.com/4349709/27274171-27486912-5487-11e7-9eab-1b8e8d2acaf9.png)
After:
![2017-06-19-003437_462x824_scrot](https://user-images.githubusercontent.com/4349709/27274177-2ae85258-5487-11e7-9eb7-5e56fbfbc077.png)



Let me know what you think!