### PR TITLE
add_colon_on_first_item

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -636,6 +636,8 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
             }
         });
 
+        mEditText.setAddColonOnFirstItem(true);
+
         mSendingMessagesLayout = findViewById(R.id.room_sending_message_layout);
         mSendImageView = (ImageView) findViewById(R.id.room_send_image_view);
         mSendButtonLayout = findViewById(R.id.room_send_layout);

--- a/vector/src/main/java/im/vector/view/VectorAutoCompleteTextView.java
+++ b/vector/src/main/java/im/vector/view/VectorAutoCompleteTextView.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v7.widget.AppCompatMultiAutoCompleteTextView;
+import android.text.Editable;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -64,6 +65,8 @@ public class VectorAutoCompleteTextView extends AppCompatMultiAutoCompleteTextVi
     // trick to fix the list width
     private android.widget.ListPopupWindow mListPopupWindow;
 
+    // add a colon when the inserted text is the first item of the string
+    private boolean mAddColonOnFirstItem;
 
     public VectorAutoCompleteTextView(Context context) {
         super(context, null);
@@ -186,6 +189,36 @@ public class VectorAutoCompleteTextView extends AppCompatMultiAutoCompleteTextVi
             // setDropDownWidth(maxWidth) does not work on some devices
             // it seems working on android >= 5.1
             // but it does not on older android platforms
+        }
+    }
+
+    /**
+     * Set if a colon must be appended to the inserted text
+     * if it is the first item of the string
+     *
+     * @param addColonOnFirstItem true to insert colon
+     */
+    public void setAddColonOnFirstItem(boolean addColonOnFirstItem) {
+        mAddColonOnFirstItem = addColonOnFirstItem;
+    }
+
+    @Override
+    protected void replaceText(CharSequence text) {
+        String before = getText().toString();
+        super.replaceText(text);
+
+        if (mAddColonOnFirstItem) {
+            try {
+                Editable editableAfter = getText();
+
+                // check if the inserted becomes was the new first item
+                if ((null != before) && !before.startsWith(text.toString()) &&
+                        editableAfter.toString().startsWith(text.toString())) {
+                    editableAfter.replace(0, text.length(), text + ":");
+                }
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "## replaceText() : failed " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
fix https://github.com/vector-im/riot-android/issues/1330
Using the name completion as the first item of the message should add a colon (:)