### PR TITLE
Back to live btn in preview

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -178,6 +178,7 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
     public static final int GET_MENTION_REQUEST_CODE = 2;
     private static final int REQUEST_ROOM_AVATAR_CODE = 3;
     private static final int INVITE_USER_REQUEST_CODE = 4;
+    public static final int UNREAD_PREVIEW_REQUEST_CODE = 5;
 
     private VectorMessageListFragment mVectorMessageListFragment;
     private MXSession mSession;
@@ -859,10 +860,12 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
         // or in room preview mode
         // the edition items are not displayed
         if ((!TextUtils.isEmpty(mEventId) || (null != sRoomPreviewData))) {
-            mNotificationsArea.setVisibility(View.GONE);
-            findViewById(R.id.bottom_separator).setVisibility(View.GONE);
-            findViewById(R.id.room_notification_separator).setVisibility(View.GONE);
-            findViewById(R.id.room_notifications_area).setVisibility(View.GONE);
+            if (!mIsUnreadPreviewMode) {
+                mNotificationsArea.setVisibility(View.GONE);
+                findViewById(R.id.bottom_separator).setVisibility(View.GONE);
+                findViewById(R.id.room_notification_separator).setVisibility(View.GONE);
+                findViewById(R.id.room_notifications_area).setVisibility(View.GONE);
+            }
 
             View v = findViewById(R.id.room_bottom_layout);
             ViewGroup.LayoutParams params = v.getLayoutParams();
@@ -1197,6 +1200,8 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
                         }
                     });
                 }
+            } else if (requestCode == UNREAD_PREVIEW_REQUEST_CODE){
+                mVectorMessageListFragment.scrollToBottom(0);
             }
         }
     }
@@ -2138,6 +2143,18 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
             iconId = R.drawable.error;
             textColor = R.color.vector_fuchsia_color;
             text = new SpannableString(getResources().getString(R.string.room_offline_notification));
+        } else if(mIsUnreadPreviewMode){
+            isAreaVisible = true;
+            iconId = R.drawable.scrolldown;
+            textColor = R.color.vector_text_gray_color;
+
+            mNotificationIconImageView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    setResult(RESULT_OK);
+                    finish();
+                }
+            });
         } else {
             List<Event> undeliveredEvents = mSession.getDataHandler().getStore().getUndeliverableEvents(mRoom.getRoomId());
             List<Event> unknownDeviceEvents = mSession.getDataHandler().getStore().getUnknownDeviceEvents(mRoom.getRoomId());
@@ -2232,7 +2249,9 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
             }
         }
 
-        if (TextUtils.isEmpty(mEventId)) {
+        if (mIsUnreadPreviewMode) {
+            mNotificationsArea.setVisibility(View.VISIBLE);
+        } else if (TextUtils.isEmpty(mEventId)) {
             mNotificationsArea.setVisibility(isAreaVisible ? View.VISIBLE : View.INVISIBLE);
         }
 

--- a/vector/src/main/java/im/vector/util/ReadMarkerManager.java
+++ b/vector/src/main/java/im/vector/util/ReadMarkerManager.java
@@ -402,7 +402,7 @@ public class ReadMarkerManager implements MessagesAdapter.ReadMarkerListener {
             intent.putExtra(MXCActionBarActivity.EXTRA_MATRIX_ID, mSession.getMyUserId());
             intent.putExtra(VectorRoomActivity.EXTRA_EVENT_ID, eventId);
             intent.putExtra(VectorRoomActivity.EXTRA_IS_UNREAD_PREVIEW_MODE, true);
-            mActivity.startActivity(intent);
+            mActivity.startActivityForResult(intent, VectorRoomActivity.UNREAD_PREVIEW_REQUEST_CODE);
         }
     }
 

--- a/vector/src/main/res/layout/activity_vector_room.xml
+++ b/vector/src/main/res/layout/activity_vector_room.xml
@@ -364,29 +364,30 @@
             <RelativeLayout
                 android:id="@+id/room_notifications_area"
                 android:layout_width="match_parent"
-                android:minHeight="42dp"
                 android:layout_height="wrap_content"
-                android:layout_alignParentLeft="true"
                 android:layout_above="@id/bottom_separator"
+                android:layout_alignParentLeft="true"
+                android:minHeight="42dp"
                 android:visibility="invisible">
 
                 <ImageView
                     android:id="@+id/room_notification_icon"
-                    android:layout_marginLeft="25dp"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
+                    android:layout_width="34dp"
+                    android:layout_height="34dp"
                     android:layout_centerVertical="true"
-                    android:src="@drawable/vector_typing"/>
+                    android:layout_marginLeft="20dp"
+                    android:padding="5dp"
+                    android:src="@drawable/vector_typing" />
 
                 <TextView
                     android:id="@+id/room_notification_message"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
-                    android:layout_marginLeft="73dp"
+                    android:layout_marginLeft="68dp"
                     android:layout_marginRight="13dp"
-                    android:textColor="@color/vector_text_gray_color"
-                    android:text="a text here " />
+                    android:text="a text here "
+                    android:textColor="@color/vector_text_gray_color" />
 
             </RelativeLayout>
 


### PR DESCRIPTION
- On room preview (open by "jump to first unread"), if the user hits the "jump to bottom" icon, it now closes the preview to bring back the user **at the bottom** of the live (differs from the back button since the back button closes the preview with the live remaining where it was before opening the preview)

- Add some padding around the "jump to bottom" icon so it's easier to tap on it