### PR TITLE
fix_crash_mark_all_as_read

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -2211,7 +2211,7 @@ public class VectorHomeActivity extends AppCompatActivity implements SearchView.
     /**
      * Warn the displayed fragment about summary updates.
      */
-    private void dispatchOnSummariesUpdate() {
+    public void dispatchOnSummariesUpdate() {
         Fragment fragment = getSelectedFragment();
 
         if ((null != fragment) && (fragment instanceof AbsHomeFragment)) {

--- a/vector/src/main/java/im/vector/fragments/AbsHomeFragment.java
+++ b/vector/src/main/java/im/vector/fragments/AbsHomeFragment.java
@@ -409,9 +409,20 @@ public abstract class AbsHomeFragment extends Fragment implements AbsAdapter.Inv
         mSession.markRoomsAsRead(getRooms(), new ApiCallback<Void>() {
             @Override
             public void onSuccess(Void info) {
-                mActivity.stopWaitingView();
-                mActivity.refreshUnreadBadges();
-                onSummariesUpdate();
+                // check if the activity is still attached
+                if ((null != mActivity) && !mActivity.isFinishing()) {
+                    mActivity.stopWaitingView();
+                    mActivity.refreshUnreadBadges();
+
+                    // if the fragment is still the active one
+                    if (isResumed()) {
+                        // refresh it
+                        onSummariesUpdate();
+                    } else {
+                        // refresh the displayed one
+                        mActivity.dispatchOnSummariesUpdate();
+                    }
+                }
             }
 
             private void onError(String errorMessage) {

--- a/vector/src/main/java/im/vector/fragments/FavouritesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/FavouritesFragment.java
@@ -181,8 +181,12 @@ public class FavouritesFragment extends AbsHomeFragment implements HomeRoomAdapt
 
     @Override
     public void onSummariesUpdate() {
-        if (!mActivity.isWaitingViewVisible()) {
-            refreshFavorites();
+        super.onSummariesUpdate();
+            
+        if (isResumed()) {
+            if (!mActivity.isWaitingViewVisible()) {
+                refreshFavorites();
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/fragments/HomeFragment.java
+++ b/vector/src/main/java/im/vector/fragments/HomeFragment.java
@@ -237,8 +237,12 @@ public class HomeFragment extends AbsHomeFragment implements HomeRoomAdapter.OnS
 
     @Override
     public void onSummariesUpdate() {
-        if (!mActivity.isWaitingViewVisible()) {
-            initData();
+        super.onSummariesUpdate();
+
+        if (isResumed()) {
+            if (!mActivity.isWaitingViewVisible()) {
+                initData();
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/fragments/PeopleFragment.java
+++ b/vector/src/main/java/im/vector/fragments/PeopleFragment.java
@@ -445,10 +445,13 @@ public class PeopleFragment extends AbsHomeFragment implements ContactsManager.C
     @Override
     public void onSummariesUpdate() {
         super.onSummariesUpdate();
-        mAdapter.setInvitation(mActivity.getRoomInvitations());
 
-        initDirectChatsData();
-        initDirectChatsViews();
+        if (isResumed()) {
+            mAdapter.setInvitation(mActivity.getRoomInvitations());
+
+            initDirectChatsData();
+            initDirectChatsViews();
+        }
     }
 
     @Override

--- a/vector/src/main/java/im/vector/fragments/RoomsFragment.java
+++ b/vector/src/main/java/im/vector/fragments/RoomsFragment.java
@@ -202,8 +202,11 @@ public class RoomsFragment extends AbsHomeFragment implements AbsHomeFragment.On
     @Override
     public void onSummariesUpdate() {
         super.onSummariesUpdate();
-        refreshRooms();
-        mAdapter.setInvitation(mActivity.getRoomInvitations());
+
+        if (isResumed()) {
+            refreshRooms();
+            mAdapter.setInvitation(mActivity.getRoomInvitations());
+        }
     }
 
     /*


### PR DESCRIPTION
fix https://github.com/vector-im/riot-android/issues/1410
crash when the mark all response is received whereas the user switches to another fragment