### PR TITLE
Dismiss the soft keyboard

### DIFF
--- a/vector/src/main/java/im/vector/activity/LoginActivity.java
+++ b/vector/src/main/java/im/vector/activity/LoginActivity.java
@@ -537,6 +537,14 @@ public class LoginActivity extends MXCActionBarActivity implements RegistrationM
         mUseCustomHomeServersCheckbox.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                // Remove the keyboard to show the new views.
+                InputMethodManager imm = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+                
+                // Check if the keyboard is open and hide it.
+                if(imm.isAcceptingText()) {
+                    imm.hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
+                }
+                
                 mUseCustomHomeServersCheckbox.post(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
I think it is a nice idea to dismiss the keyboard if the user ticks the check box to show the custom server settings. This way the EditText views are immediately visible instead of having to scroll down first.

I'll leave this up to the developers to actually implement or not.