### PR TITLE
Add privacy and UX related options

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -1748,7 +1748,8 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
      */
     private void handleTypingNotification(boolean isTyping) {
         int notificationTimeoutMS = -1;
-        if (isTyping) {
+        boolean typingNotificationsEnabled = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean(getString(R.string.settings_send_typing_notifications), true);
+        if (isTyping && typingNotificationsEnabled) {
             // Check whether a typing event has been already reported to server (We wait for the end of the local timeout before considering this new event)
             if (null != mTypingTimer) {
                 // Refresh date of the last observed typing
@@ -1822,6 +1823,9 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
             mLastTypingDate = 0;
         }
 
+        if (!typingNotificationsEnabled) {
+            return;
+        }
         final boolean typingStatus = isTyping;
 
         mRoom.sendTypingNotification(typingStatus, notificationTimeoutMS, new SimpleApiCallback<Void>(VectorRoomActivity.this) {
@@ -2319,6 +2323,11 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
      */
     private void onRoomTypings() {
         mLatestTypingMessage = null;
+
+        if (!PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean(getString(R.string.settings_show_typing_notifications), true)) {
+            refreshNotificationsArea();
+            return;
+        }
 
         List<String> typingUsers = mRoom.getTypingUsers();
 

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -25,6 +25,7 @@ import android.graphics.Point;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.preference.PreferenceManager;
 import android.support.v4.content.ContextCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -33,6 +34,7 @@ import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
+import android.util.TypedValue;
 import android.view.Display;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -1042,6 +1044,7 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
 
         SpannableString body = new SpannableString((null == textualDisplay) ? "" : textualDisplay);
         final TextView bodyTextView = (TextView) convertView.findViewById(R.id.messagesAdapter_body);
+        bodyTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, getTextAppearance());
 
         // cannot refresh it
         if (null == bodyTextView) {
@@ -1096,6 +1099,18 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
         addContentViewListeners(convertView, bodyTextView, position);
 
         return convertView;
+    }
+
+    private float getTextAppearance() {
+        String size = PreferenceManager.getDefaultSharedPreferences(mContext).getString(mContext.getString(R.string.settings_font_size), "small");
+        switch (size) {
+            case "medium":
+                return 18;
+            case "large":
+                return 22;
+            default:
+                return 14;
+        }
     }
 
     /**

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -18,6 +18,7 @@ package im.vector.adapters;
 
 import android.content.Context;
 import android.net.Uri;
+import android.preference.PreferenceManager;
 import android.text.Html;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -388,7 +389,7 @@ public class VectorMessagesAdapterHelper {
         IMXStore store = mSession.getDataHandler().getStore();
 
         // sanity check
-        if (null == roomState) {
+        if (null == roomState || !PreferenceManager.getDefaultSharedPreferences(mContext).getBoolean(mContext.getString(R.string.settings_show_read_receipts), true)) {
             avatarsListView.setVisibility(View.GONE);
             return;
         }

--- a/vector/src/main/res/values/array.xml
+++ b/vector/src/main/res/values/array.xml
@@ -40,5 +40,15 @@
         <item>@string/room_settings_read_history_entry_value_members_only_invited</item>
         <item>@string/room_settings_read_history_entry_value_members_only_joined</item>
     </string-array>
+    <string-array name="font_size_text">
+        <item>@string/settings_font_size_small</item>
+        <item>@string/settings_font_size_medium</item>
+        <item>@string/settings_font_size_large</item>
+    </string-array>
+    <string-array name="font_size_values" translatable="false">
+        <item>small</item>
+        <item>medium</item>
+        <item>large</item>
+    </string-array>
 
 </resources>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -559,6 +559,7 @@
     <string name="settings_phone_number_verification_error_empty_code">Enter an activation code</string>
     <string name="settings_phone_number_verification_error">Error while validating your phone number</string>
     <string name="settings_phone_number_code">Code</string>
+    <string name="settings_use_markdown">Use markdown</string>
     <string name="settings_show_read_receipts">Show read receipts</string>
     <string name="settings_send_typing_notifications">Send typing notifications</string>
     <string name="settings_show_typing_notifications">Show typing notifications</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -559,11 +559,14 @@
     <string name="settings_phone_number_verification_error_empty_code">Enter an activation code</string>
     <string name="settings_phone_number_verification_error">Error while validating your phone number</string>
     <string name="settings_phone_number_code">Code</string>
+    <string name="settings_font_size">Messages font size</string>
+    <string name="settings_font_size_small">Small</string>
+    <string name="settings_font_size_medium">Medium</string>
+    <string name="settings_font_size_large">Large</string>
     <string name="settings_use_markdown">Use markdown</string>
     <string name="settings_show_read_receipts">Show read receipts</string>
     <string name="settings_send_typing_notifications">Send typing notifications</string>
     <string name="settings_show_typing_notifications">Show typing notifications</string>
-
     <!-- Room Settings -->
 
     <!-- room global settings-->

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -559,6 +559,9 @@
     <string name="settings_phone_number_verification_error_empty_code">Enter an activation code</string>
     <string name="settings_phone_number_verification_error">Error while validating your phone number</string>
     <string name="settings_phone_number_code">Code</string>
+    <string name="settings_show_read_receipts">Show read receipts</string>
+    <string name="settings_send_typing_notifications">Send typing notifications</string>
+    <string name="settings_show_typing_notifications">Show typing notifications</string>
 
     <!-- Room Settings -->
 

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -245,6 +245,21 @@
         android:key="@string/settings_other" >
 
         <im.vector.preference.VectorSwitchPreference
+            android:title="@string/settings_show_read_receipts"
+            android:key="@string/settings_show_read_receipts"
+            android:defaultValue="true"/>
+
+        <im.vector.preference.VectorSwitchPreference
+            android:title="@string/settings_send_typing_notifications"
+            android:key="@string/settings_send_typing_notifications"
+            android:defaultValue="true"/>
+
+        <im.vector.preference.VectorSwitchPreference
+            android:title="@string/settings_show_typing_notifications"
+            android:key="@string/settings_show_typing_notifications"
+            android:defaultValue="true"/>
+
+        <im.vector.preference.VectorSwitchPreference
             android:title="@string/ga_use_settings"
             android:key="@string/ga_use_settings"/>
 

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -245,6 +245,11 @@
         android:key="@string/settings_other" >
 
         <im.vector.preference.VectorSwitchPreference
+            android:title="@string/settings_use_markdown"
+            android:key="MARKDOWN_PREFERENCE_KEY"
+            android:defaultValue="true"/>
+
+        <im.vector.preference.VectorSwitchPreference
             android:title="@string/settings_show_read_receipts"
             android:key="@string/settings_show_read_receipts"
             android:defaultValue="true"/>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -244,6 +244,13 @@
         android:title="@string/settings_other"
         android:key="@string/settings_other" >
 
+        <ListPreference
+            android:defaultValue="?android:attr/textAppearanceSmall"
+            android:entries="@array/font_size_text"
+            android:entryValues="@array/font_size_values"
+            android:key="@string/settings_font_size"
+            android:title="@string/settings_font_size"/>
+
         <im.vector.preference.VectorSwitchPreference
             android:title="@string/settings_use_markdown"
             android:key="MARKDOWN_PREFERENCE_KEY"


### PR DESCRIPTION
Allow to disable showing read receipts and showing/sending type notifications, disable markdown with a visual setting (currently is only possible via undocumented /markdown off command), change the message font size.