### PR TITLE
Fix an NPE in the search results

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorSearchMessagesListAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorSearchMessagesListAdapter.java
@@ -114,7 +114,9 @@ public class VectorSearchMessagesListAdapter extends VectorMessagesAdapter {
 
         // display the sender
         TextView senderTextView = (TextView) convertView.findViewById(R.id.messagesAdapter_sender);
-        senderTextView.setText(VectorMessagesAdapterHelper.getUserDisplayName(event.getSender(), roomState));
+        if (senderTextView != null) {
+            senderTextView.setText(VectorMessagesAdapterHelper.getUserDisplayName(event.getSender(), roomState));
+        }
 
         // display the body
         TextView bodyTextView = (TextView) convertView.findViewById(R.id.messagesAdapter_body);


### PR DESCRIPTION
When searching in messages there could be adapters that lack the sender text view like topic change notifications. In that case Riot crashes. I propose to just skip setting the sender on such layouts.