### PR TITLE
WIP: Different application IDs for different configs

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -10,7 +10,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "im.vector"
+        applicationId "im.vector.alpha"
         minSdkVersion 16
         targetSdkVersion 25
         // use the version code
@@ -32,6 +32,7 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix ".dev"
             resValue "string", "git_revision", "\"${gitRevision()}\""
             resValue "string", "git_revision_date", "\"${gitRevisionDate()}\""
             resValue "string", "git_branch_name", "\"${gitBranchName()}\""
@@ -54,7 +55,6 @@ android {
 
     productFlavors {
         app {
-            applicationId "im.vector.alpha"
             // use the version name
             versionCode rootProject.ext.versionCodeProp
             versionName rootProject.ext.versionNameProp
@@ -65,7 +65,7 @@ android {
         }
 
         appfdroid {
-            applicationId "im.vector.alpha"
+            applicationIdSuffix ".fdroid"
             // use the version name
             versionCode rootProject.ext.versionCodeProp
             versionName rootProject.ext.versionNameProp


### PR DESCRIPTION
A unique application ID based on buildType and productFlavor.
This has the advantage, that people can install dev builds alongside stable builds, either for trying out the dev build, or for having a stable backup, should the dev build break. 

This is also somewhat related to #1353, because this at least allows people to install the app 4 times, which should be enough for most people, and does so without having multiple apps in one store (which can be confusing).