### PR TITLE
fix handling of pusher removal when it got removed already (fix #1582)

### DIFF
--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -837,6 +837,11 @@ public final class GcmRegistrationManager {
 
             @Override
             public void onMatrixError(MatrixError e) {
+                if (e.mStatus == 404) {
+                    // httpPusher is not available on server side anymore so assume the removal was successful
+                    onSuccess(null);
+                    return;
+                }
                 if (null != callback) {
                     callback.onMatrixError(e);
                 }
@@ -898,6 +903,11 @@ public final class GcmRegistrationManager {
 
                             @Override
                             public void onMatrixError(MatrixError e) {
+                                if (e.mStatus == 404) {
+                                    // httpPusher is not available on server side anymore so assume the removal was successful
+                                    onSuccess(null);
+                                    return;
+                                }
                                 Log.e(LOG_TAG, "unregisterSession onMatrixError " + e.errcode);
                                 onError(e.getLocalizedMessage());
                             }


### PR DESCRIPTION
e.g. when the server decides to remove a pusher e.g. because it failed to
push to that endpoint, removal of the pusher failes with a response code of
"404". This PR now let the client assume that it was successful when a 404
respond occurs

Signed-off-by: Matthias Kesler <krombel@krombel.de>