### PR TITLE
"Black" theme for the OLED screen joy

### DIFF
--- a/vector/src/main/java/im/vector/util/ThemeUtils.java
+++ b/vector/src/main/java/im/vector/util/ThemeUtils.java
@@ -66,6 +66,7 @@ public class ThemeUtils {
     // the theme description
     public static final String THEME_DARK_VALUE = "dark";
     public static final String THEME_LIGHT_VALUE = "light";
+    public static final String THEME_BLACK_VALUE = "black";
 
 
     public static Map<Integer, Integer> mColorByAttr = new HashMap<>();
@@ -106,7 +107,11 @@ public class ThemeUtils {
 
         if (TextUtils.equals(aTheme, THEME_DARK_VALUE)) {
             VectorApp.getInstance().setTheme(R.style.AppTheme_Dark);
-        } else {
+        }
+        else if (TextUtils.equals(aTheme, THEME_BLACK_VALUE)) {
+            VectorApp.getInstance().setTheme(R.style.AppTheme_Black);
+        }
+        else {
             VectorApp.getInstance().setTheme(R.style.AppTheme);
         }
 
@@ -168,6 +173,58 @@ public class ThemeUtils {
                 activity.setTheme(R.style.AppTheme_Dark);
             } else if (activity instanceof VectorUniversalLinkActivity) {
                 activity.setTheme(R.style.AppTheme_Dark);
+            }
+        }
+
+        if (TextUtils.equals(getApplicationTheme(activity), THEME_BLACK_VALUE)) {
+            if (activity instanceof AccountCreationActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof AccountCreationActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof CountryPickerActivity) {
+                activity.setTheme(R.style.CountryPickerTheme_Black);
+            } else if (activity instanceof FallbackLoginActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof HistoricalRoomsActivity) {
+                activity.setTheme(R.style.HomeActivityTheme_Black);
+            } else if (activity instanceof InComingCallActivity) {
+                activity.setTheme(R.style.CallAppTheme_Black);
+            } else if (activity instanceof LanguagePickerActivity) {
+                activity.setTheme(R.style.CountryPickerTheme_Black);
+            } else if (activity instanceof LoginActivity) {
+                activity.setTheme(R.style.LoginAppTheme_Black);
+            } else if (activity instanceof PhoneNumberAdditionActivity) {
+                activity.setTheme(R.style.AppTheme_NoActionBar_Black);
+            } else if (activity instanceof PhoneNumberVerificationActivity) {
+                activity.setTheme(R.style.AppTheme_NoActionBar_Black);
+            } else if (activity instanceof RoomDirectoryPickerActivity) {
+                activity.setTheme(R.style.DirectoryPickerTheme_Black);
+            } else if (activity instanceof SplashActivity) {
+                activity.setTheme(R.style.AppTheme_NoActionBar_Black);
+            } else if (activity instanceof VectorBaseSearchActivity) {
+                activity.setTheme(R.style.SearchesAppTheme_Black);
+            } else if (activity instanceof VectorCallViewActivity) {
+                activity.setTheme(R.style.CallActivityTheme_Black);
+            } else if (activity instanceof VectorHomeActivity) {
+                activity.setTheme(R.style.HomeActivityTheme_Black);
+            } else if (activity instanceof VectorMediasPickerActivity) {
+                activity.setTheme(R.style.AppTheme_NoActionBar_FullScreen_Black);
+            } else if (activity instanceof VectorMediasViewerActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof VectorMemberDetailsActivity) {
+                activity.setTheme(R.style.AppTheme_NoActionBar_Black);
+            } else if (activity instanceof VectorPublicRoomsActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof VectorRoomActivity) {
+                activity.setTheme(R.style.AppTheme_NoActionBar_Black);
+            } else if (activity instanceof VectorRoomCreationActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof VectorRoomDetailsActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof VectorSettingsActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof VectorUniversalLinkActivity) {
+                activity.setTheme(R.style.AppTheme_Black);
             }
         }
 

--- a/vector/src/main/res/drawable/avatar_mask_black.xml
+++ b/vector/src/main/res/drawable/avatar_mask_black.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="-50dp"
+        android:left="-50dp"
+        android:right="-50dp"
+        android:top="-50dp">
+        <shape android:shape="oval" >
+            <solid android:color="@android:color/transparent" />
+
+            <stroke
+                android:width="50dp"
+                android:color="@color/riot_primary_background_color_black" />
+        </shape>
+    </item>
+</layer-list>

--- a/vector/src/main/res/values/colors.xml
+++ b/vector/src/main/res/values/colors.xml
@@ -23,6 +23,7 @@
     <!-- dedicated drawables are created for each theme -->
     <color name="riot_primary_background_color_light">@android:color/white</color>
     <color name="riot_primary_background_color_dark">#2d2d2d</color>
+    <color name="riot_primary_background_color_black">#000000</color>
 
     <color name="primary_color_light">#76CFA6</color>
     <color name="primary_color_dark">#353535</color>

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -24,6 +24,7 @@
     <string-array name="theme_codes">
         <item>light</item>
         <item>dark</item>
+        <item>black</item>
     </string-array>
 
 </resources>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string-array name="theme_readables">
         <item>Light Theme</item>
         <item>Dark Theme</item>
+        <item>Black Theme</item>
     </string-array>
 
     <!-- titles -->

--- a/vector/src/main/res/values/styles.xml
+++ b/vector/src/main/res/values/styles.xml
@@ -480,5 +480,161 @@
 
         <item name="android:listDivider">@null</item>
     </style>
+    
+    <!--  ************************  Black theme  **************************** -->
+
+    <style name="AppTheme.NoActionBar.Black" parent="@style/Theme.Vector.Black">
+        <!-- disable the overscroll because setOverscrollHeader/Footer don't always work -->
+        <item name="android:overScrollMode">never</item>
+
+        <!-- hide the action bar -->
+        <item name="android:windowActionBar">false</item>
+        <item name="windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="windowNoTitle">true</item>
+
+        <!-- status bar color -->
+        <item name="colorPrimaryDark">?attr/primary_dark_color</item>
+
+        <!-- fonts -->
+        <item name="android:typeface">sans</item>
+
+        <!-- activities background -->
+        <item name="android:windowBackground">@color/riot_primary_background_color_dark</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar.Swipe.Black" parent="@style/AppTheme.NoActionBar.Black">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
+
+    <style name="HomeActivityTheme.Black" parent="AppTheme.NoActionBar.Black">
+        <item name="editTextColor">?attr/riot_primary_text_color</item>
+        <item name="android:editTextColor">?attr/riot_primary_text_color</item>
+        <item name="android:textColorHint">?attr/default_text_hint_color</item>
+    </style>
+
+    <style name="CallActivityTheme.Black" parent="AppTheme.Black">
+        <item name="android:windowNoTitle">true</item>
+        <item name="windowNoTitle">true</item>
+        <!-- status bar color -->
+        <item name="colorPrimaryDark">@android:color/black</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar.FullScreen.Black" parent="@style/AppTheme.NoActionBar.Black">
+        <item name="android:windowFullscreen">true</item>
+        <!-- activities background -->
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
+
+    <style name="AppTheme.ActionBar.FullScreen.Black" parent="@style/AppTheme.NoActionBar.FullScreen.Black">
+        <!-- show the action bar -->
+        <item name="android:windowActionBar">true</item>
+        <item name="windowActionBar">true</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+
+    <style name="AppTheme.Black" parent="@style/Theme.Vector.Black">
+
+        <!-- disable the overscroll because setOverscrollHeader/Footer don't always work -->
+        <item name="android:overScrollMode">never</item>
+
+        <!-- with action bar -->
+        <item name="android:windowActionBar">true</item>
+
+        <!-- status bar color -->
+        <item name="colorPrimaryDark">?attr/primary_dark_color</item>
+
+        <!-- activities background -->
+        <item name="android:windowBackground">@color/riot_primary_background_color_black</item>
+
+        <!-- fonts -->
+        <item name="android:typeface">sans</item>
+
+        <!-- android ui button -->
+        <item name="colorAccent">@color/vector_green_color</item>
+
+        <!-- custom action bar -->
+        <item name="android:actionBarStyle">@style/Vector.Styled.ActionBar</item>
+        <item name="actionBarStyle">@style/Vector.Styled.ActionBar</item>
+
+        <!-- actionbar icons color -->
+        <item name="actionBarTheme">@style/Vector.ActionBarTheme</item>
+
+        <!-- remove the shadow under the actionbar -->
+        <item name="android:windowContentOverlay">@null</item>
+
+        <item name="android:popupMenuStyle">@style/vector.PopupMenu</item>
+
+        <!-- tabbar background -->
+        <item name="android:actionBarTabStyle">@style/Vector.TabView.Dark</item>
+        <item name="actionBarTabStyle">@style/Vector.TabView.Dark</item>
+
+        <!-- tabbar text color -->
+        <item name="android:actionBarTabTextStyle">@style/Vector.TabText</item>
+        <item name="actionBarTabTextStyle">@style/Vector.TabText</item>
+
+        <!-- no divider -->
+        <item name="android:actionBarDivider">@null</item>
+
+        <!-- switch color -->
+        <item name="colorControlActivated">@color/vector_green_color</item>
+    </style>
+
+    <style name="LoginAppTheme.Black" parent="AppTheme.NoActionBar.Black">
+        <item name="android:editTextStyle">@style/LoginEditTextStyle</item>
+        <item name="android:buttonStyle">@style/LoginButtonStyle</item>
+        <item name="colorAccent">?attr/editTextColor</item>
+    </style>
+
+
+    <style name="CountryPickerTheme.Black" parent="AppTheme.NoActionBar.Black">
+        <item name="editTextColor">@android:color/white</item>
+        <item name="android:editTextColor">@android:color/white</item>
+        <item name="android:textColorHint">?attr/activity_bottom_gradient_color</item>
+    </style>
+
+    <style name="DirectoryPickerTheme.Black" parent="AppTheme.NoActionBar.Black"></style>
+
+    <style name="SearchesAppTheme.Black" parent="AppTheme.Black">
+        <!-- custom action bar -->
+        <item name="android:actionBarStyle">@style/VectorSearches.Styled.ActionBar</item>
+        <item name="actionBarStyle">@style/VectorSearches.Styled.ActionBar</item>
+
+        <!-- no divider -->
+        <item name="android:actionBarDivider">@null</item>
+
+        <!-- edittext -->
+        <item name="android:editTextStyle">@style/VectorSearches.EditText</item>
+
+        <!-- actionbar icons color -->
+        <item name="actionBarTheme">@style/VectorSearches.ActionBarTheme</item>
+
+    </style>
+
+    <style name="CallAppTheme.Black" parent="AppTheme.NoActionBar.Black">
+        <item name="android:colorBackground">?attr/colorBackgroundFloating</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+
+        <item name="android:windowFrame">@null</item>
+        <item name="android:windowTitleStyle">@style/RtlOverlay.DialogWindowTitle.AppCompat</item>
+        <item name="android:windowTitleBackgroundStyle">@style/Base.DialogWindowTitleBackground.AppCompat</item>
+        <item name="android:windowBackground">@drawable/abc_dialog_material_background</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowAnimationStyle">@style/Animation.AppCompat.Dialog</item>
+        <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>
+
+        <item name="windowActionBar">false</item>
+        <item name="windowActionModeOverlay">true</item>
+
+        <item name="listPreferredItemPaddingLeft">24dip</item>
+        <item name="listPreferredItemPaddingRight">24dip</item>
+
+        <item name="android:listDivider">@null</item>
+    </style>
 
 </resources>

--- a/vector/src/main/res/values/themes.xml
+++ b/vector/src/main/res/values/themes.xml
@@ -180,4 +180,11 @@
         <item name="vector_tabbar_unselected_background">@drawable/vector_tabbar_unselected_background_dark</item>
         <item name="vector_tabbar_background">@drawable/vector_tabbar_background_dark</item>
     </style>
+    
+    <!-- BLACK THEME COLORS -->
+    <style name="Theme.Vector.Black" parent="@style/Theme.Vector.Dark">
+        <!-- Only setting the items we need to override to get the background to be pure black, otherwise inheriting -->
+        <item name="riot_primary_background_color">@color/riot_primary_background_color_black</item>
+        <item name="avatar_mask">@drawable/avatar_mask_black</item>
+    </style>
 </resources>


### PR DESCRIPTION
Well, [the Twitter account called my bluff](https://twitter.com/RiotChat/status/908586586165702656), so I half-remembered how to develop for Android and added this child of the the Dark Theme!

I tried to slim down my additions a bit, but I bet it could be a lot less verbose in `styles.xml` or at least in `ThemeUtils.java` with some refactoring of `setActivityTheme()`, and speaking of `ThemeUtils.java` perhaps I should have done something in regards to `getResourceId()`? Still, what I do have definitely appears to work, and though this pull request in GitHub in my browser is searing my 3AM eyes, glancing down at my Nexus 6P running Riot.im is a comforting relief of minimal light :)