### PR TITLE
Make use of jenkins BUILD_NUMBER in versionCode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     versionBuild = System.getenv("BUILD_NUMBER") as Integer ?: 0
 
     versionCodeProp = versionMajor * 1000000 + versionMinor * 100000 + versionPatch * 10000 + versionBuild
-    versionNameProp = "${versionMajor}.${versionMinor}.${versionPatch}-dev"
+    versionNameProp = "${versionMajor}.${versionMinor}.${versionPatch}.${versionBuild}-dev"
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,13 @@ buildscript {
 
 // global properties used in sub modules
 ext {
-    versionCodeProp = 70400
-    versionNameProp = "0.7.04-dev"
+    versionMajor = 0
+    versionMinor = 7
+    versionPatch = 4
+    versionBuild = System.getenv("BUILD_NUMBER") as Integer ?: 0
+
+    versionCodeProp = versionMajor * 1000000 + versionMinor * 100000 + versionPatch * 10000 + versionBuild
+    versionNameProp = "${versionMajor}.${versionMinor}.${versionPatch}-dev"
 }
 
 allprojects {


### PR DESCRIPTION
The fdroid client uses the versionCode to determine if updates are available.
If the jenkins-build-number (passed as variable BUILD_NUMBER in the env) would have an effect on the versionCode it would be possible that the fdoid-client notifies the users of the dev-build-repo of a new build.

In the current situation the new versionCodeProp would be set to 741660

Signed-Off-by: Matthias Kesler <krombel@krombel.de>