### PR TITLE
Compile against API 26 (Android Oreo).

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '25.0.2'
 
     packagingOptions {


### PR DESCRIPTION
This closes #1633. Rather than targetSdkVersion, we change compileSdkVersion (see difference

Changing targetSdkVersion also makes sense, but since there are no automated test suite, I cannot test that everything works fine with that. The main benefit would apparently be that the visuals may be prettier.