### PR TITLE
fix_bt_management

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -61,7 +61,9 @@
     <uses-permission android:name="com.majeur.launcher.permission.UPDATE_BADGE" />
 
     <!-- bluetooth headset -->
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+
     <uses-feature
         android:name="android.hardware.bluetooth"
         android:required="false" />
@@ -442,6 +444,16 @@
         </receiver>
 
         <receiver android:name="im.vector.receiver.DismissNotificationReceiver"/>
+
+        <receiver android:name="im.vector.receiver.HeadsetConnectionReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.HEADSET_PLUG"/>
+                <action android:name="android.bluetooth.adapter.action.STATE_CHANGED" />
+                <action android:name="android.bluetooth.adapter.action.CONNECTION_STATE_CHANGED" />
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+            </intent-filter>
+        </receiver>
 
         <!-- Shared items  -->
         <activity

--- a/vector/src/main/java/im/vector/VectorApp.java
+++ b/vector/src/main/java/im/vector/VectorApp.java
@@ -70,7 +70,6 @@ import im.vector.contacts.ContactsManager;
 import im.vector.contacts.PIDsRetriever;
 import im.vector.ga.GAHelper;
 import im.vector.gcm.GcmRegistrationManager;
-import im.vector.receiver.HeadsetConnectionReceiver;
 import im.vector.services.EventStreamService;
 import im.vector.util.BugReporter;
 import im.vector.util.PhoneNumberUtils;
@@ -301,9 +300,6 @@ public class VectorApp extends MultiDexApplication {
                 }
             }
         });
-
-        // detect if the headset is plugged / unplugged.
-        registerReceiver(new HeadsetConnectionReceiver(), new IntentFilter(Intent.ACTION_HEADSET_PLUG));
 
         // create the markdown parser
         try {

--- a/vector/src/main/java/im/vector/util/VectorCallSoundManager.java
+++ b/vector/src/main/java/im/vector/util/VectorCallSoundManager.java
@@ -19,6 +19,8 @@ package im.vector.util;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.Ringtone;
@@ -591,15 +593,12 @@ public class VectorCallSoundManager {
         if ((null != mAudioMode) && (null != mIsSpeakerOn)) {
             AudioManager audioManager = getAudioManager();
 
-            // ignore speaker button if a headset is connected
-            if (!audioManager.isBluetoothA2dpOn() && !audioManager.isWiredHeadsetOn()) {
-                if (mAudioMode!= audioManager.getMode()) {
-                    audioManager.setMode(mAudioMode);
-                }
+            if (mAudioMode != audioManager.getMode()) {
+                audioManager.setMode(mAudioMode);
+            }
 
-                if (mIsSpeakerOn != audioManager.isSpeakerphoneOn()) {
-                    audioManager.setSpeakerphoneOn(mIsSpeakerOn);
-                }
+            if (mIsSpeakerOn != audioManager.isSpeakerphoneOn()) {
+                audioManager.setSpeakerphoneOn(mIsSpeakerOn);
             }
 
             mAudioMode = null;
@@ -637,6 +636,20 @@ public class VectorCallSoundManager {
 
             if (audioManager.getMode() != audioMode) {
                 audioManager.setMode(audioMode);
+            }
+
+            if (!isSpeakerOn) {
+                try {
+                    if (HeadsetConnectionReceiver.isBTHeadsetPlugged()) {
+                        audioManager.startBluetoothSco();
+                        audioManager.setBluetoothScoOn(true);
+                    } else if (audioManager.isBluetoothScoOn()) {
+                        audioManager.stopBluetoothSco();
+                        audioManager.setBluetoothScoOn(false);
+                    }
+                } catch (Exception e) {
+                    Log.e(LOG_TAG, "## setSpeakerphoneOn() failed " + e.getMessage());
+                }
             }
 
             if (isSpeakerOn != audioManager.isSpeakerphoneOn()) {


### PR DESCRIPTION
Add bluetooth headset management

should fix 
#1639 : killed bluetooth headphone, can't play music or voice call in other apps after using voice/video call in riot 
#1525 : Audio does not come through bluetooth headsets when paired and om video or voice call. tested with unknown modern LG headset from T-Mobile store and with personal Samsung Level U Pro bluetooth headset Version 0316-LUPRO-K-4
#1493 : In calls, all audio is routed into the top speaker. My Bluetooth earphones with mic that I use to answer normal calls stop working during riot calls. I haven't tested with normal earphones but I doubt it's different.
#919 : Voice calls (even unsuccessful ones) break bluetooth media headsets 

