### PR TITLE
Implement theme for quick reply screen

### DIFF
--- a/vector/src/main/java/im/vector/util/ThemeUtils.java
+++ b/vector/src/main/java/im/vector/util/ThemeUtils.java
@@ -20,6 +20,7 @@ package im.vector.util;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.preference.PreferenceManager;
 import android.support.annotation.AttrRes;
 import android.support.annotation.ColorInt;
@@ -38,6 +39,7 @@ import im.vector.activity.FallbackLoginActivity;
 import im.vector.activity.HistoricalRoomsActivity;
 import im.vector.activity.InComingCallActivity;
 import im.vector.activity.LanguagePickerActivity;
+import im.vector.activity.LockScreenActivity;
 import im.vector.activity.LoginActivity;
 import im.vector.activity.PhoneNumberAdditionActivity;
 import im.vector.activity.PhoneNumberVerificationActivity;
@@ -172,6 +174,8 @@ public class ThemeUtils {
                 activity.setTheme(R.style.AppTheme_Dark);
             } else if (activity instanceof VectorUniversalLinkActivity) {
                 activity.setTheme(R.style.AppTheme_Dark);
+            } else if (activity instanceof LockScreenActivity) {
+                activity.setTheme(R.style.Vector_Lock_Dark);
             }
         }
 
@@ -224,6 +228,15 @@ public class ThemeUtils {
                 activity.setTheme(R.style.AppTheme_Black);
             } else if (activity instanceof VectorUniversalLinkActivity) {
                 activity.setTheme(R.style.AppTheme_Black);
+            } else if (activity instanceof LockScreenActivity) {
+                activity.setTheme(R.style.Vector_Lock_Black);
+            }
+        }
+
+        if (TextUtils.equals(getApplicationTheme(activity), THEME_LIGHT_VALUE)) {
+            // Specific quirk for quick reply screen
+            if (activity instanceof LockScreenActivity) {
+                activity.setTheme(R.style.Vector_Lock_Light);
             }
         }
 

--- a/vector/src/main/res/layout/activity_lock_screen.xml
+++ b/vector/src/main/res/layout/activity_lock_screen.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/lock_main_layout"
     android:layout_width="200dp"
     android:layout_height="wrap_content"
@@ -15,6 +16,7 @@
         android:paddingTop="5dp"
         android:text="Room name"
         android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="?attr/riot_primary_text_color"
         android:textStyle="bold" />
 
     <View
@@ -32,6 +34,7 @@
         android:paddingTop="5dp"
         android:text="SENDER"
         android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?attr/riot_primary_text_color"
         android:textStyle="bold" />
 
     <TextView
@@ -43,6 +46,7 @@
         android:paddingRight="5dp"
         android:text="A message body goes here"
         android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?attr/message_text_color"
         android:textIsSelectable="false" />
 
     <LinearLayout

--- a/vector/src/main/res/values/colors.xml
+++ b/vector/src/main/res/values/colors.xml
@@ -36,4 +36,19 @@
 
     <color name="tab_bar_unselected_background_color_light">@color/primary_color_light</color>
     <color name="tab_bar_unselected_background_color_dark">@color/primary_color_dark</color>
+
+    <!-- Text Colors -->
+    <color name="primary_hint_text_color_light">#BBE7D3</color>
+    <color name="primary_hint_text_color_dark">#BBE7D3</color>
+
+    <color name="riot_primary_text_color_light">#FF3C3C3C</color>
+    <color name="default_text_hint_color_light">#903C3C3C</color>
+    <color name="default_text_light_color_light">#8E000000</color>
+    <color name="default_button_light_text_light">#FF747474</color>
+    <color name="default_text_dark_color_light">#FF212121</color>
+    <color name="riot_primary_text_color_dark">#dddddd</color>
+    <color name="default_text_hint_color_dark">#CCDDDDDD</color>
+    <color name="default_text_light_color_dark">#A4A4A4</color>
+    <color name="default_button_light_text_dark">#FF747474</color>
+    <color name="default_text_dark_color_dark">#DEDEDE</color>
 </resources>

--- a/vector/src/main/res/values/styles.xml
+++ b/vector/src/main/res/values/styles.xml
@@ -637,4 +637,20 @@
         <item name="android:listDivider">@null</item>
     </style>
 
+    <style name="Vector_Lock_Light" parent="Theme.Vector.EmptyLight">
+        <item name="android:background">?attr/riot_primary_background_color</item>
+        <item name="android:textColor">?attr/primary_text_color</item>
+        <item name="editTextColor">?attr/riot_primary_text_color</item>
+        <item name="android:editTextColor">?attr/riot_primary_text_color</item>
+    </style>
+    <style name="Vector_Lock_Dark" parent="Theme.Vector.EmptyDark">
+        <item name="android:background">?attr/riot_primary_background_color</item>
+        <item name="editTextColor">@android:color/white</item>
+        <item name="android:textColor">?attr/primary_text_color</item>
+        <item name="android:editTextColor">?attr/riot_primary_text_color</item>
+    </style>
+    <style name="Vector_Lock_Black" parent="Theme.Vector.EmptyBlack">
+        <item name="android:background">?attr/primary_color</item>
+        <item name="android:textColor">?attr/riot_primary_text_color</item>
+    </style>
 </resources>

--- a/vector/src/main/res/values/themes.xml
+++ b/vector/src/main/res/values/themes.xml
@@ -21,14 +21,14 @@
         <item name="primary_control_color">@android:color/white</item>
 
         <!-- application bar text hint color -->
-        <item name="primary_hint_text_color">#BBE7D3</item>
+        <item name="primary_hint_text_color">@color/primary_hint_text_color_light</item>
 
         <!-- default text colors -->
-        <item name="riot_primary_text_color">#FF3C3C3C</item>
-        <item name="default_text_hint_color">#903C3C3C</item>
-        <item name="default_text_light_color">#8E000000</item>
-        <item name="default_button_light_text_color">#FF747474</item>
-        <item name="default_text_dark_color">#FF212121</item>
+        <item name="riot_primary_text_color">@color/riot_primary_text_color_light</item>
+        <item name="default_text_hint_color">@color/default_text_hint_color_light</item>
+        <item name="default_text_light_color">@color/default_text_light_color_light</item>
+        <item name="default_button_light_text_color">@color/default_button_light_text_light</item>
+        <item name="default_text_dark_color">@color/default_text_light_color_light</item>
 
         <!-- room message colors -->
         <item name="unsent_message_text_color">#FFFF4444</item>
@@ -112,14 +112,14 @@
         <item name="primary_control_color">#5EA584</item>
 
         <!-- application bar text hint color -->
-        <item name="primary_hint_text_color">#BBE7D3</item>
+        <item name="primary_hint_text_color">@color/primary_hint_text_color_dark</item>
 
         <!-- default text colors -->
-        <item name="riot_primary_text_color">#dddddd</item>
-        <item name="default_text_hint_color">#CCDDDDDD</item>
-        <item name="default_text_light_color">#A4A4A4</item>
-        <item name="default_button_light_text_color">#FF747474</item>
-        <item name="default_text_dark_color">#DEDEDE</item>
+        <item name="riot_primary_text_color">@color/riot_primary_text_color_dark</item>
+        <item name="default_text_hint_color">@color/default_text_hint_color_dark</item>
+        <item name="default_text_light_color">@color/default_text_light_color_dark</item>
+        <item name="default_button_light_text_color">@color/default_button_light_text_dark</item>
+        <item name="default_text_dark_color">@color/default_text_light_color_dark</item>
 
         <!-- room message colors -->
         <item name="unsent_message_text_color">#FFFF4444</item>
@@ -188,5 +188,24 @@
         <item name="avatar_mask">@drawable/avatar_mask_black</item>
         <item name="avatar_mask_white_stroke">@drawable/avatar_mask_white_stroke_black</item>
         <item name="markdown_block_background_color">#FF4D4D4D</item>
+    </style>
+
+    <style name="Theme.Vector.EmptyLight" parent="">
+        <item name="primary_color">@color/primary_color_light</item>
+        <item name="riot_primary_background_color">@color/riot_primary_background_color_light</item>
+        <item name="riot_primary_text_color">@color/riot_primary_text_color_light</item>
+        <item name="primary_hint_text_color">@color/primary_hint_text_color_light</item>
+        <item name="message_text_color">?attr/riot_primary_text_color</item>
+    </style>
+    <style name="Theme.Vector.EmptyDark" parent="">
+        <item name="riot_primary_text_color">@color/riot_primary_text_color_dark</item>
+        <item name="riot_primary_background_color">@color/riot_primary_background_color_dark</item>
+        <item name="primary_hint_text_color">@color/primary_hint_text_color_dark</item>
+        <item name="primary_color">@color/primary_color_dark</item>
+        <item name="message_text_color">?attr/riot_primary_text_color</item>
+    </style>
+    <style name="Theme.Vector.EmptyBlack" parent="@style/Theme.Vector.EmptyDark">
+        <item name="riot_primary_background_color">@color/riot_primary_background_color_black</item>
+        <item name="primary_color">@color/riot_primary_background_color_black</item>
     </style>
 </resources>


### PR DESCRIPTION
Closes #1662 

I also moved a couple colors written in themes into the colors.xml file to reduce potential duplciation.

As far as I can tell, this is the only way to do this, since the quick reply screen has it's own theme (setting an appcompat theme resizes the window).

Please let me know if you think there's a better way to do this, and I'll switch this to use that way instead!

White (same as before):
![screenshot_1508095755](https://user-images.githubusercontent.com/4349709/31588350-8b5bcf90-b1be-11e7-9db4-f03848ca39df.png)
Dark:
![screenshot_1508095803](https://user-images.githubusercontent.com/4349709/31588353-8fd6127e-b1be-11e7-955a-fe684a1b65b5.png)
Black:
![screenshot_1508095820](https://user-images.githubusercontent.com/4349709/31588356-96541d12-b1be-11e7-9b9c-5afa3e07bb59.png)

