### PR TITLE
Remove html text replacer

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -571,7 +571,7 @@ public class VectorMessagesAdapterHelper {
 
             // the links are not yet supported by ConsoleHtmlTagHandler
             // the markdown tables are not properly supported
-            sequence = Html.fromHtml(htmlFormattedText.replace("\n", "<br/>"), null, isCustomizable ? htmlTagHandler : null);
+            sequence = Html.fromHtml(htmlFormattedText, null, isCustomizable ? htmlTagHandler : null);
 
             // sanity check
             if (!TextUtils.isEmpty(sequence)) {


### PR DESCRIPTION
The replace function that replaces newlines with break tags does not seem to have a good use and breaks other things (see issue #1663 for example). I think the replace function was meant to improve the table layout, but as markdown tables are not supported by commonmark, it only causes formatting issues right now. 