### PR TITLE
Fixes #145: improve the code display (double and triple backticks)

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -552,6 +552,45 @@ class VectorMessagesAdapterHelper {
         }
     }
 
+    /** Determine how many backticks bracket a message, for code block
+     * handling (issue 145) */
+    public int getTickCount(final Message message) {
+        final String mb = message.body;
+        if (mb.startsWith("```") && mb.endsWith("```")) {
+            return 3;
+        }
+        else if (mb.startsWith("``") && mb.endsWith("``")) {
+            return 2;
+        }
+        else if (mb.startsWith("`") && mb.endsWith("`")) {
+            return 1;
+        }
+        else {
+            return 0;
+        }
+    }
+
+    /** Handling for ROW_TYPE_CODE (issue 145) */
+    void highlightCode(final TextView textView, final Spannable text, final int tickCount) {
+        // sanity check
+        if (null == textView) {
+            return;
+        }
+
+        final int background = (tickCount==1) ?
+                ThemeUtils.getColor(mContext, R.attr.code_block_1_background_color) :
+                (tickCount==2) ?
+                ThemeUtils.getColor(mContext, R.attr.code_block_2_background_color) :
+                ThemeUtils.getColor(mContext, R.attr.code_block_3_background_color);
+        textView.setBackgroundColor(background);
+
+        textView.setText(text);
+
+        if (null != mLinkMovementMethod) {
+            textView.setMovementMethod(mLinkMovementMethod);
+        }
+    }
+
     /**
      * Highlight the pattern in the text.
      *

--- a/vector/src/main/java/im/vector/adapters/VectorSearchMessagesListAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorSearchMessagesListAdapter.java
@@ -57,6 +57,7 @@ public class VectorSearchMessagesListAdapter extends VectorMessagesAdapter {
                 R.layout.adapter_item_vector_search_message_image_video,
                 -1,
                 R.layout.adapter_item_vector_search_message_emoji,
+                R.layout.adapter_item_vector_message_code,
                 mediasCache);
 
         setNotifyOnChange(true);

--- a/vector/src/main/res/layout/adapter_item_vector_message_code.xml
+++ b/vector/src/main/res/layout/adapter_item_vector_message_code.xml
@@ -85,24 +85,15 @@
                             android:layout_height="14dp"
                             android:src="@drawable/e2e_verified" />
 
-                        <HorizontalScrollView
+                        <LinearLayout
+                            android:id="@+id/messages_container"
                             android:layout_width="match_parent"
-                            android:layout_height="match_parent">
-
-                            <TextView
-                                android:id="@+id/messagesAdapter_body"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="left"
-                                android:layout_marginLeft="4dp"
-                                android:layout_toRightOf="@id/message_adapter_e2e_icon"
-                                android:autoLink="none"
-                                android:fontFamily="monospace"
-                                android:text="A body"
-                                android:textIsSelectable="false"
-                                android:textSize="14sp" />
-                        </HorizontalScrollView>
-
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:layout_gravity="left"
+                            android:layout_marginLeft="4dp"
+                            android:layout_toRightOf="@id/message_adapter_e2e_icon"
+                            />
                     </RelativeLayout>
 
                 </FrameLayout>

--- a/vector/src/main/res/layout/adapter_item_vector_message_code.xml
+++ b/vector/src/main/res/layout/adapter_item_vector_message_code.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <include
+        layout="@layout/vector_message_header"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:id="@+id/messagesAdapter_body_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/messagesAdapter_roundAvatar"
+            layout="@layout/vector_room_round_avatar" />
+
+        <View
+            android:id="@+id/messagesAdapter_highlight_message_marker"
+            android:layout_width="6dp"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"
+            android:background="#f00" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingBottom="5dp">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_toLeftOf="@+id/message_timestamp_layout"
+                    android:orientation="horizontal">
+
+                    <include layout="@layout/vector_message_sender" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/message_timestamp_layout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:orientation="horizontal">
+
+                    <include layout="@layout/vector_message_timestamp" />
+                </LinearLayout>
+            </RelativeLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <FrameLayout
+                    android:id="@+id/messagesAdapter_body_layout"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingRight="4dp">
+
+                    <!-- the body is here -->
+                    <RelativeLayout
+                        android:id="@+id/messagesAdapter_text_layout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="left">
+
+                        <ImageView
+                            android:id="@+id/message_adapter_e2e_icon"
+                            android:layout_width="14dp"
+                            android:layout_height="14dp"
+                            android:src="@drawable/e2e_verified" />
+
+                        <HorizontalScrollView
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent">
+
+                            <TextView
+                                android:id="@+id/messagesAdapter_body"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="left"
+                                android:layout_marginLeft="4dp"
+                                android:layout_toRightOf="@id/message_adapter_e2e_icon"
+                                android:autoLink="none"
+                                android:fontFamily="monospace"
+                                android:text="A body"
+                                android:textIsSelectable="false"
+                                android:textSize="14sp" />
+                        </HorizontalScrollView>
+
+                    </RelativeLayout>
+
+                </FrameLayout>
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+
+    <include
+        android:id="@+id/messagesAdapter_avatars_list"
+        layout="@layout/vector_message_receipts_list" />
+
+    <include layout="@layout/message_separator" />
+
+    <include layout="@layout/message_read_marker" />
+
+</LinearLayout>

--- a/vector/src/main/res/layout/adapter_item_vector_message_code_block.xml
+++ b/vector/src/main/res/layout/adapter_item_vector_message_code_block.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/messagesAdapter_body_hsv"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
+
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/messagesAdapter_body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_marginLeft="4dp"
+            android:autoLink="none"
+            android:fontFamily="monospace"
+            android:text="A body"
+            android:textIsSelectable="false"
+            android:textSize="14sp" />
+    </HorizontalScrollView>
+</LinearLayout>

--- a/vector/src/main/res/layout/adapter_item_vector_message_code_text.xml
+++ b/vector/src/main/res/layout/adapter_item_vector_message_code_text.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/messagesAdapter_body"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="left"
+    android:layout_marginLeft="4dp"
+    android:autoLink="all"
+    android:text="A body"
+    android:textIsSelectable="false"
+    android:textSize="14sp" />

--- a/vector/src/main/res/values/attrs.xml
+++ b/vector/src/main/res/values/attrs.xml
@@ -41,9 +41,7 @@
         <attr name="search_mode_room_name_text_color" format="color" />
         <attr name="unread_marker_line_color" format="color" />
         <attr name="markdown_block_background_color" format="color" />
-        <attr name="code_block_1_background_color" format="color" />
-        <attr name="code_block_2_background_color" format="color" />
-        <attr name="code_block_3_background_color" format="color" />
+        <attr name="fenced_code_block_background_color" format="color" />
         <attr name="room_activity_divider_color" format="color" />
 
         <!-- tab bar colors -->

--- a/vector/src/main/res/values/attrs.xml
+++ b/vector/src/main/res/values/attrs.xml
@@ -41,6 +41,9 @@
         <attr name="search_mode_room_name_text_color" format="color" />
         <attr name="unread_marker_line_color" format="color" />
         <attr name="markdown_block_background_color" format="color" />
+        <attr name="code_block_1_background_color" format="color" />
+        <attr name="code_block_2_background_color" format="color" />
+        <attr name="code_block_3_background_color" format="color" />
         <attr name="room_activity_divider_color" format="color" />
 
         <!-- tab bar colors -->

--- a/vector/src/main/res/values/themes.xml
+++ b/vector/src/main/res/values/themes.xml
@@ -41,9 +41,7 @@
         <item name="search_mode_room_name_text_color">#333C3C3C</item>
         <item name="unread_marker_line_color">@color/vector_green_color</item>
         <item name="markdown_block_background_color">#FFEEEEEE</item>
-        <item name="code_block_1_background_color">#FFCD0000</item>
-        <item name="code_block_2_background_color">#FFFFB6C1</item>
-        <item name="code_block_3_background_color">#FF00FF00</item>
+        <item name="fenced_code_block_background_color">#FF00FF00</item>
         <item name="room_activity_divider_color">#FFF2F2F2</item>
 
         <!-- tab bar colors -->
@@ -148,9 +146,7 @@
         <item name="search_mode_room_name_text_color">#CCC3C3C3</item>
         <item name="unread_marker_line_color">@color/vector_green_color</item>
         <item name="markdown_block_background_color">@android:color/black</item>
-        <item name="code_block_1_background_color">#FFCD0000</item>
-        <item name="code_block_2_background_color">#FFFFB6C1</item>
-        <item name="code_block_3_background_color">#FF00FF00</item>
+        <item name="fenced_code_block_background_color">#FF00FF00</item>
         <item name="room_activity_divider_color">#565656</item>
 
         <!-- tab bar colors -->
@@ -221,9 +217,7 @@
         <item name="avatar_mask">@drawable/avatar_mask_black</item>
         <item name="avatar_mask_white_stroke">@drawable/avatar_mask_white_stroke_black</item>
         <item name="markdown_block_background_color">#FF4D4D4D</item>
-        <item name="code_block_1_background_color">#FFCD0000</item>
-        <item name="code_block_2_background_color">#FFFFB6C1</item>
-        <item name="code_block_3_background_color">#FF00FF00</item>
+        <item name="fenced_code_block_background_color">#FF00FF00</item>
     </style>
 
     <style name="Theme.Vector.EmptyLight" parent="">

--- a/vector/src/main/res/values/themes.xml
+++ b/vector/src/main/res/values/themes.xml
@@ -41,6 +41,9 @@
         <item name="search_mode_room_name_text_color">#333C3C3C</item>
         <item name="unread_marker_line_color">@color/vector_green_color</item>
         <item name="markdown_block_background_color">#FFEEEEEE</item>
+        <item name="code_block_1_background_color">#FFCD0000</item>
+        <item name="code_block_2_background_color">#FFFFB6C1</item>
+        <item name="code_block_3_background_color">#FF00FF00</item>
         <item name="room_activity_divider_color">#FFF2F2F2</item>
 
         <!-- tab bar colors -->
@@ -145,6 +148,9 @@
         <item name="search_mode_room_name_text_color">#CCC3C3C3</item>
         <item name="unread_marker_line_color">@color/vector_green_color</item>
         <item name="markdown_block_background_color">@android:color/black</item>
+        <item name="code_block_1_background_color">#FFCD0000</item>
+        <item name="code_block_2_background_color">#FFFFB6C1</item>
+        <item name="code_block_3_background_color">#FF00FF00</item>
         <item name="room_activity_divider_color">#565656</item>
 
         <!-- tab bar colors -->
@@ -215,6 +221,9 @@
         <item name="avatar_mask">@drawable/avatar_mask_black</item>
         <item name="avatar_mask_white_stroke">@drawable/avatar_mask_white_stroke_black</item>
         <item name="markdown_block_background_color">#FF4D4D4D</item>
+        <item name="code_block_1_background_color">#FFCD0000</item>
+        <item name="code_block_2_background_color">#FFFFB6C1</item>
+        <item name="code_block_3_background_color">#FF00FF00</item>
     </style>
 
     <style name="Theme.Vector.EmptyLight" parent="">


### PR DESCRIPTION
Fixes #145: "improve the code display (double and triple backticks)"

Introduces a new ROW_TYPE_CODE for messages that contain a mixture of fenced (i.e. 3 backtick) code blocks and text sections. The text sections can contain in-line (unfenced) code blocks. Each of the fenced code blocks is in its own HorizontalScrollView and independently scrollable.

This is done via a new layout adapter_item_vector_message_code.xml, which can contain a mixture of  adapter_item_vector_message_code_block.xml and adapter_item_vector_message_code_text.xml layouts. 

A different background colour for fenced code blocks can be specified using the new attribute fenced_code_block_background_color. The current colour is by way of example only, and is intended to be changed by designers.

![issue145_fixed_screenie_postreview](https://user-images.githubusercontent.com/19371062/34157064-da8ead72-e4b7-11e7-941f-33ef1208be8c.png)

Screenshot showing a single message containing:
* two fenced (3 backtick) code blocks, one of which has been scrolled
* a plain text section containing inline code
* plain text sections with no code