### PR TITLE
Upgraded gradle plugin support libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.google.gms:google-services:3.1.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -23,9 +24,6 @@ ext {
 allprojects {
     repositories {
         jcenter()
-
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 18 15:42:37 CEST 2017
+#Fri Dec 22 10:34:48 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -139,60 +139,60 @@ def gitBranchName() {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.android.support:multidex:1.0.2'
+    implementation 'com.android.support:multidex:1.0.2'
 
-    compile 'me.leolin:ShortcutBadger:1.1.2@aar'
+    implementation 'me.leolin:ShortcutBadger:1.1.2@aar'
 
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support:design:27.0.2'
-    compile 'com.android.support:cardview-v7:27.0.2'
-    compile 'com.android.support:recyclerview-v7:27.0.2'
-    compile 'com.jakewharton:butterknife:8.5.1'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:cardview-v7:27.0.2'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
+    implementation 'com.jakewharton:butterknife:8.5.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
 
-    compile 'com.squareup.retrofit:retrofit:1.6.1'
-    compile 'com.google.code.gson:gson:2.3'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.retrofit:retrofit:1.6.1'
+    implementation 'com.google.code.gson:gson:2.3'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
 
-    compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.+'
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.+'
 
-    compile 'com.googlecode.libphonenumber:libphonenumber:8.0.1'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.0.1'
 
     /************* Matrix SDK management **************/
     // update settings.gradle
     // use the matrix SDK as external lib
-    compile(name: 'matrix-sdk', ext: 'aar')
+    implementation(name: 'matrix-sdk', ext: 'aar')
     // use the matrix SDK as a sub project
     //compile project(':matrix-sdk')
-    compile(name: 'olm-sdk', ext: 'aar')
+    implementation(name: 'olm-sdk', ext: 'aar')
 
     /************* jitsi **************/
-    compile 'javax.inject:javax.inject:1'
-    compile 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.0.0'
-    compile 'com.facebook.fresco:fresco:0.11.0'
-    compile 'com.facebook.fresco:imagepipeline-okhttp3:0.11.0'
-    compile 'com.facebook.soloader:soloader:0.1.0'
-    compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-ws:3.4.1'
-    compile 'com.squareup.okio:okio:1.9.0'
-    compile 'org.webkit:android-jsc:r174650'
+    implementation 'javax.inject:javax.inject:1'
+    implementation 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.0.0'
+    implementation 'com.facebook.fresco:fresco:0.11.0'
+    implementation 'com.facebook.fresco:imagepipeline-okhttp3:0.11.0'
+    implementation 'com.facebook.soloader:soloader:0.1.0'
+    implementation 'com.google.code.findbugs:jsr305:3.0.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.4.1'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
+    implementation 'com.squareup.okhttp3:okhttp-ws:3.4.1'
+    implementation 'com.squareup.okio:okio:1.9.0'
+    implementation 'org.webkit:android-jsc:r174650'
 
-    compile(name: 'jitsi-sdk', ext: 'aar')
-    compile(name: 'react-native-background-timer', ext: 'aar')
-    compile(name: 'react-native-fetch-blob', ext: 'aar')
-    compile(name: 'react-native-immersive', ext: 'aar')
-    compile(name: 'react-native-keep-awake', ext: 'aar')
-    compile(name: 'react-native-vector-icons', ext: 'aar')
-    compile(name: 'react-native-webrtc', ext: 'aar')
-    compile(name: 'react-native', ext: 'aar')
+    implementation(name: 'jitsi-sdk', ext: 'aar')
+    implementation(name: 'react-native-background-timer', ext: 'aar')
+    implementation(name: 'react-native-fetch-blob', ext: 'aar')
+    implementation(name: 'react-native-immersive', ext: 'aar')
+    implementation(name: 'react-native-keep-awake', ext: 'aar')
+    implementation(name: 'react-native-vector-icons', ext: 'aar')
+    implementation(name: 'react-native-webrtc', ext: 'aar')
+    implementation(name: 'react-native', ext: 'aar')
 
     // another tracking than GA
-    compile 'org.piwik.sdk:piwik-sdk:2.0.0'
+    implementation 'org.piwik.sdk:piwik-sdk:2.0.0'
 
     // use the matrix SDK as a part of the project
     // you have to uncomment some lines in settings.gradle
@@ -201,8 +201,8 @@ dependencies {
     /************* flavors management **************/
 
     // app flavor only
-    appCompile 'com.google.firebase:firebase-core:11.6.2'
-    appCompile 'com.google.firebase:firebase-messaging:11.6.2'
+    implementation 'com.google.firebase:firebase-core:11.6.2'
+    implementation 'com.google.firebase:firebase-messaging:11.6.2'
 
     // fdroid flavor only
 }

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.2'
 
     packagingOptions {
         exclude 'META-INF/LICENSE'
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "im.vector"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         // use the version code
         versionCode rootProject.ext.versionCodeProp
         versionName rootProject.ext.versionNameProp
@@ -74,6 +74,8 @@ android {
         }
     }
 
+    flavorDimensions "default"
+
     productFlavors {
         app {
             applicationId "im.vector.alpha"
@@ -84,6 +86,7 @@ android {
             resValue "string", "allow_ga_use", "true"
             resValue "string", "short_flavor_description", "G"
             resValue "string", "flavor_description", "GooglePlay"
+            dimension "default"
         }
 
         appfdroid {
@@ -95,6 +98,7 @@ android {
             resValue "string", "allow_ga_use", "false"
             resValue "string", "short_flavor_description", "F"
             resValue "string", "flavor_description", "FDroid"
+            dimension "default"
         }
     }
 
@@ -137,14 +141,14 @@ def gitBranchName() {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.android.support:multidex:1.0.0'
+    compile 'com.android.support:multidex:1.0.2'
 
     compile 'me.leolin:ShortcutBadger:1.1.2@aar'
 
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support:cardview-v7:26.1.0'
-    compile 'com.android.support:recyclerview-v7:26.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:design:27.0.2'
+    compile 'com.android.support:cardview-v7:27.0.2'
+    compile 'com.android.support:recyclerview-v7:27.0.2'
     compile 'com.jakewharton:butterknife:8.5.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
 


### PR DESCRIPTION
Just for starters:

- Upgraded gradle plugin to 3.0.1
- Upgraded google services to newest version
-  Upgraded gradle to 4.1
-  Upgraded build tools to 27.0.2
-  Upgraded compiled SDK to 27
-  Upgraded support libraries to 27.0.2
-  Upgraded multidex support library
- Changed `compile` target to `implementation` 