### PR TITLE
Add support for Android O "pinned shortcuts"

### DIFF
--- a/vector/src/main/java/im/vector/fragments/AbsHomeFragment.java
+++ b/vector/src/main/java/im/vector/fragments/AbsHomeFragment.java
@@ -260,6 +260,11 @@ public abstract class AbsHomeFragment extends Fragment implements AbsAdapter.Roo
         });
     }
 
+    @Override
+    public void addHomescreenShortcut(MXSession session, String roomId) {
+        RoomUtils.addHomescreenShortcut(getActivity(), session, roomId);
+    }
+
     /*
      * *********************************************************************************************
      * Public methods

--- a/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
@@ -742,6 +742,11 @@ public class VectorRecentsListFragment extends Fragment implements VectorRoomSum
     }
 
     @Override
+    public void addHomescreenShortcut(MXSession session, String roomId) {
+        RoomUtils.addHomescreenShortcut(getActivity(), session, roomId);
+    }
+
+    @Override
     public void onToggleRoomNotifications(MXSession session, String roomId) {
         BingRulesManager bingRulesManager = session.getDataHandler().getBingRulesManager();
 

--- a/vector/src/main/res/menu/vector_home_room_settings.xml
+++ b/vector/src/main/res/menu/vector_home_room_settings.xml
@@ -28,6 +28,12 @@
             android:title="@string/room_settings_leave_conversation" />
     </group>
 
+    <group android:id="@+id/add_shortcut_actions">
+        <item
+            android:id="@+id/ic_action_add_homescreen_shortcut"
+            android:title="Add Homescreen Shortcut" />
+    </group>
+
     <group android:id="@+id/historical_room_actions">
         <item
             android:id="@+id/action_forget_room"


### PR DESCRIPTION
Allow user to pin a shortcut to the homescreen for
quick access to a room.

Currently the shortcut only uses "Room Avatar" (default icon), because there isn't a clean way to access the avatarUrl image cleanly to generate the icon.