### PR TITLE
issue 145: enhancements to previous fixes for code block display

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -1209,12 +1209,15 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
         for (final String block:blocks) {
             if (block.startsWith(START_FB) && block.endsWith(END_FB)) {
                 // Fenced block
-                final String stripped = block.substring(START_FB.length(), block.length()-END_FB.length());
-                final SpannableString threeTickBlock = new SpannableString(stripped);
+                final String minusTags = block.substring(START_FB.length(), block.length()-END_FB.length());
                 final View blockView = mLayoutInflater.inflate(R.layout.adapter_item_vector_message_code_block, null);
                 container.addView(blockView);
                 final TextView tv = blockView.findViewById(R.id.messagesAdapter_body);
-                mHelper.highlightFencedCode(tv, threeTickBlock);
+                highlightPattern(tv, new SpannableString(minusTags),
+                        TextUtils.equals(Message.FORMAT_MATRIX_HTML, message.format) ? mHelper.getSanitisedHtml(minusTags) : null,
+                        mPattern, shouldHighlighted);
+
+                mHelper.highlightFencedCode(tv);
                 textViews.add(tv);
 
                 ((View)tv.getParent()).setBackgroundColor(ThemeUtils.getColor(mContext, R.attr.markdown_block_background_color));

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -1204,32 +1204,27 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
         container.removeAllViews();
 
         final String[] blocks = mHelper.getFencedCodeBlocks(message);
-        for (int i = 0; i < blocks.length; i++) {
-
-            // Start of fenced block
-            if (blocks[i].equals("```") && i <= blocks.length - 3 && blocks[i + 2].equals("```")) {
-                final SpannableString threeTickBlock = new SpannableString(blocks[i + 1]);
+        final String START_FB = VectorMessagesAdapterHelper.START_FENCED_BLOCK;
+        final String END_FB = VectorMessagesAdapterHelper.END_FENCED_BLOCK;
+        for (final String block:blocks) {
+            if (block.startsWith(START_FB) && block.endsWith(END_FB)) {
+                // Fenced block
+                final String stripped = block.substring(START_FB.length(), block.length()-END_FB.length());
+                final SpannableString threeTickBlock = new SpannableString(stripped);
                 final View blockView = mLayoutInflater.inflate(R.layout.adapter_item_vector_message_code_block, null);
                 container.addView(blockView);
                 final TextView tv = blockView.findViewById(R.id.messagesAdapter_body);
                 mHelper.highlightFencedCode(tv, threeTickBlock);
-                i += 2;
                 textViews.add(tv);
 
                 ((View)tv.getParent()).setBackgroundColor(ThemeUtils.getColor(mContext, R.attr.markdown_block_background_color));
             } else {
                 // Not a fenced block
                 final TextView tv = (TextView) mLayoutInflater.inflate(R.layout.adapter_item_vector_message_code_text, null);
-                final String ithBlock = blocks[i];
-                VectorApp.markdownToHtml(blocks[i],
-                        new VectorMarkdownParser.IVectorMarkdownParserListener() {
-                            @Override
-                            public void onMarkdownParsed(final String text, final String HTMLText) {
-                                highlightPattern(tv, new SpannableString(ithBlock),
-                                        TextUtils.equals(Message.FORMAT_MATRIX_HTML, message.format) ? mHelper.getSanitisedHtml(HTMLText) : null,
-                                        mPattern, shouldHighlighted);
-                            }
-                        });
+
+                highlightPattern(tv, new SpannableString(block),
+                        TextUtils.equals(Message.FORMAT_MATRIX_HTML, message.format) ? mHelper.getSanitisedHtml(block) : null,
+                        mPattern, shouldHighlighted);
 
                 container.addView(tv);
                 textViews.add(tv);

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -84,9 +84,12 @@ class VectorMessagesAdapterHelper {
     private static final String LOG_TAG = VectorMessagesAdapterHelper.class.getSimpleName();
 
     /**
-     * Enable multiline mode, split on ```
+     * Enable multiline mode, split on <pre><code>...</code></pre> and retain those delimiters in
+     * the returned fenced block.
      */
-    private static final Pattern FENCED_CODE_BLOCK_PATTERN = Pattern.compile("(?m)(?<=```)|(?=```)");
+    public static final String START_FENCED_BLOCK = "<pre><code>";
+    public static final String END_FENCED_BLOCK = "</code></pre>";
+    private static final Pattern FENCED_CODE_BLOCK_PATTERN = Pattern.compile("(?m)(?=<pre><code>)|(?<=</code></pre>)");
 
     private IMessagesAdapterActionsListener mEventsListener;
 
@@ -732,12 +735,9 @@ class VectorMessagesAdapterHelper {
      * @return true if it contains code blocks
      */
     boolean containsFencedCodeBlocks(final Message message) {
-        if ((null == message.body) || !message.body.contains("```")) {
-            return false;
-        }
-
-        final String[] blocks = getFencedCodeBlocks(message);
-        return (blocks.length > 1);
+        return (null != message.formatted_body) &&
+                message.formatted_body.contains(START_FENCED_BLOCK) &&
+                message.formatted_body.contains(END_FENCED_BLOCK);
     }
 
     private Map<String, String[]> mCodeBlocksMap = new HashMap<>();
@@ -749,15 +749,15 @@ class VectorMessagesAdapterHelper {
      * @return the split message body
      */
     String[] getFencedCodeBlocks(final Message message) {
-        if (TextUtils.isEmpty(message.body)) {
+        if (TextUtils.isEmpty(message.formatted_body)) {
             return new String[0];
         }
 
-        String[] codeBlocks = mCodeBlocksMap.get(message.body);
+        String[] codeBlocks = mCodeBlocksMap.get(message.formatted_body);
 
         if (null == codeBlocks) {
-            codeBlocks = FENCED_CODE_BLOCK_PATTERN.split(message.body);
-            mCodeBlocksMap.put(message.body, codeBlocks);
+            codeBlocks = FENCED_CODE_BLOCK_PATTERN.split(message.formatted_body);
+            mCodeBlocksMap.put(message.formatted_body, codeBlocks);
         }
 
         return codeBlocks;

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -769,14 +769,13 @@ class VectorMessagesAdapterHelper {
      * @param textView the text view
      * @param text     the text
      */
-    void highlightFencedCode(final TextView textView, final Spannable text) {
+    void highlightFencedCode(final TextView textView) {
         // sanity check
         if (null == textView) {
             return;
         }
 
         textView.setBackgroundColor(ThemeUtils.getColor(mContext, R.attr.markdown_block_background_color));
-        textView.setText(text);
 
         if (null != mLinkMovementMethod) {
             textView.setMovementMethod(mLinkMovementMethod);

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -552,7 +552,7 @@
     <string name="settings_opt_out_of_analytics_summary">Riot collects anonymous analytics to allow us to improve the application.</string>
 
 
-    <string name="settings_disable_markdown">Disable markdown formatting</string>
+    <string name="settings_disable_markdown">Disable markdown formatting when sending</string>
     <string name="settings_data_save_mode">Data save mode</string>
 
     <string name="devices_details_dialog_title">Device details</string>


### PR DESCRIPTION
* Builds on #1811 and https://github.com/vector-im/riot-android/commit/545d46fc67a76e4b334be356f5b9cc9130cbdaa4
* For fenced code blocks, split on `<pre><code>...</code></pre>` in message.formatted_body, not triple backticks in message,body
* Tweak wording of "Disable markdown formatting" menu item to clarify it refers to sending messages, not displaying existing messages.

Note: ``` for fenced code blocks are still required to be on a separate line: this is due to the parsing code in the Matrix SDK. Also, this is the behaviour of the Riot web client. So, haven't attempted to change this. 