### PR TITLE
Wrong year in CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes in Riot 0.7.09 (2017-01-16)
+Changes in Riot 0.7.09 (2018-01-16)
 ===================================================
   
 Improvements:
@@ -10,14 +10,14 @@ Bugfixes:
  
   * #1859 : After a user redacted their own join event from HQ, Android DoSes us with /context requests.
 
-Changes in Riot 0.7.08 (2017-01-12)
+Changes in Riot 0.7.08 (2018-01-12)
 ===================================================
  
 Bugfixes:
 
  * Fix the account creation
 
-Changes in Riot 0.7.07 (2017-01-03)
+Changes in Riot 0.7.07 (2018-01-03)
 ===================================================
  
 Bugfixes:


### PR DESCRIPTION
The CHANGES file indicates recent releases as having been done in 2017, probably because of hasty copy/pasting.