### PR TITLE
SETTINGS : Re-enable rageshake

### DIFF
--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -209,8 +209,6 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
     private EditTextPreference mSyncRequestDelayPreference;
     private PreferenceCategory mLabsCategory;
     private PreferenceCategory mGroupsFlairCategory;
-    // tell if the rageshake mode is enabled
-    private boolean mIsUsedRageShake;
 
     // static constructor
     public static VectorSettingsPreferencesFragment newInstance(String matrixId) {
@@ -811,7 +809,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
 
         // Rageshake Managment
         final CheckBoxPreference useRageShakeModePref = (CheckBoxPreference) findPreference(PreferencesManager.SETTINGS_USE_RAGE_SHAKE_KEY);
-        mIsUsedRageShake = PreferencesManager.useRageshake(appContext);
+        final boolean mIsUsedRageShake = PreferencesManager.useRageshake(appContext);
 
         if(mIsUsedRageShake) {
             useRageShakeModePref.setChecked(true);

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -207,8 +207,9 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
     private EditTextPreference mSyncRequestTimeoutPreference;
     private EditTextPreference mSyncRequestDelayPreference;
     private PreferenceCategory mLabsCategory;
-
     private PreferenceCategory mGroupsFlairCategory;
+    // tell if the rageshake mode is enabled
+    public boolean mUseRageShakeMode;
 
     // static constructor
     public static VectorSettingsPreferencesFragment newInstance(String matrixId) {
@@ -793,6 +794,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
             }
         });
 
+        // SaveMode Managment
         final CheckBoxPreference dataSaveModePref = (CheckBoxPreference) findPreference(PreferencesManager.SETTINGS_DATA_SAVE_MODE_PREFERENCE_KEY);
         dataSaveModePref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
@@ -806,6 +808,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
             }
         });
 
+        // Rageshake Managment
         final CheckBoxPreference useRageShakeModePref = (CheckBoxPreference) findPreference(PreferencesManager.SETTINGS_USE_RAGE_SHAKE_KEY);
         final boolean mIsUsedRageShake = PreferencesManager.useRageshake(appContext);
 
@@ -814,16 +817,14 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
         } else {
             useBackgroundSyncPref.setChecked(false);
         }
-        
+
         useRageShakeModePref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
-                List<MXSession> sessions = Matrix.getMXSessions(getActivity());
-                for (MXSession session : sessions){
-                    session.setUseRageShakeMode((boolean) newValue);
-                }
 
-                return true;
+                setUseRageShakeMode((boolean) newValue);
+
+                return mUseRageShakeMode;
             }
         });
 
@@ -834,6 +835,15 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
         refreshIgnoredUsersList();
         refreshDevicesList();
         refreshGroupFlairsList();
+    }
+
+    /**
+     * Update the rageshake mode
+     *
+     * @param enabled true to enable the rageshake mode
+     */
+    public void setUseRageShakeMode(boolean enabled) {
+        mUseRageShakeMode = enabled;
     }
 
     @Override

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -177,6 +177,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
             refreshDisplay();
         }
     };
+
     private View mLoadingView;
     // cryptography
     private DeviceInfo mMyDeviceInfo;
@@ -209,7 +210,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
     private PreferenceCategory mLabsCategory;
     private PreferenceCategory mGroupsFlairCategory;
     // tell if the rageshake mode is enabled
-    public boolean mUseRageShakeMode;
+    private boolean mIsUsedRageShake;
 
     // static constructor
     public static VectorSettingsPreferencesFragment newInstance(String matrixId) {
@@ -810,7 +811,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
 
         // Rageshake Managment
         final CheckBoxPreference useRageShakeModePref = (CheckBoxPreference) findPreference(PreferencesManager.SETTINGS_USE_RAGE_SHAKE_KEY);
-        final boolean mIsUsedRageShake = PreferencesManager.useRageshake(appContext);
+        mIsUsedRageShake = PreferencesManager.useRageshake(appContext);
 
         if(mIsUsedRageShake) {
             useRageShakeModePref.setChecked(true);
@@ -822,9 +823,9 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
 
-                setUseRageShakeMode((boolean) newValue);
+                PreferencesManager.setUseRageshake(appContext, (boolean) newValue);
 
-                return mUseRageShakeMode;
+                return true;
             }
         });
 
@@ -835,15 +836,6 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
         refreshIgnoredUsersList();
         refreshDevicesList();
         refreshGroupFlairsList();
-    }
-
-    /**
-     * Update the rageshake mode
-     *
-     * @param enabled true to enable the rageshake mode
-     */
-    public void setUseRageShakeMode(boolean enabled) {
-        mUseRageShakeMode = enabled;
     }
 
     @Override


### PR DESCRIPTION
Use PreferenceManager to save rageshake mode instead of using the sdk
(https://github.com/vector-im/riot-android/issues/1971)
(https://github.com/matrix-org/matrix-android-sdk/pull/236)