### PR TITLE
Privacy: Riot should never pass events content to GCM

### DIFF
--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -661,8 +661,8 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
 
                         Matrix.getInstance(VectorSettingsPreferencesFragment.this.getActivity()).getSharedGCMRegistrationManager().forceSessionsRegistration(listener);
 
-                        // Display the content sending option only when the background sync is disabled.
-                        if (newValue) {
+                        // Display the content sending option only when the background sync is disabled whereas the GCM is supported.
+                        if (newValue || !gcmMgr.hasRegistrationToken()) {
                             mBackgroundSyncCategory.removePreference(allowContentSendingPref);
                         } else {
                             mBackgroundSyncCategory.addPreference(allowContentSendingPref);
@@ -693,8 +693,8 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment implem
                     }
                 });
 
-                // Hide this pref if the background sync is allowed
-                if (gcmMgr.isBackgroundSyncAllowed()) {
+                // Hide this pref if the background sync is allowed, or if the GCM is not supported
+                if (gcmMgr.isBackgroundSyncAllowed() || !gcmMgr.hasRegistrationToken()) {
                     mBackgroundSyncCategory.removePreference(allowContentSendingPref);
                 }
             }


### PR DESCRIPTION
Hide the new added option "Keep detailed notifications" if the GCM is not supported
#2051