### PR TITLE
BF: Room: Events with unexpected timestamps get stuck at the bottom of the history

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -724,7 +724,7 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
 
     @Override
     public void notifyDataSetChanged() {
-        // the event with invalid timestamp must be pushed at the end of the history
+        // undelivered events must be pushed at the end of the history
         this.setNotifyOnChange(false);
         List<MessageRow> undeliverableEvents = new ArrayList<>();
 

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -732,7 +732,7 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
             MessageRow row = getItem(i);
             Event event = row.getEvent();
 
-            if ((null != event) && (!event.isValidOriginServerTs() || event.isUnkownDevice())) {
+            if ((null != event) && (event.isUndeliverable() || event.isUnkownDevice())) {
                 undeliverableEvents.add(row);
                 remove(row);
                 i--;


### PR DESCRIPTION
#2081

Use the more recent Event.isUndeliverable() method rather than the hacky Event.isValidOriginServerTs() (which works well for the display BTW)