### PR TITLE
Notifications: Make the notification for messages no more sticky

### DIFF
--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -599,7 +599,7 @@ public class CommonActivityUtils {
             }
 
             if (null != EventStreamService.getInstance()) {
-                EventStreamService.getInstance().refreshStatusNotification();
+                EventStreamService.getInstance().refreshForegroundNotification();
             }
         }
     }

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -33,6 +33,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.preference.PreferenceManager;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.design.internal.BottomNavigationItemView;
 import android.support.design.internal.BottomNavigationMenuView;
@@ -117,6 +118,7 @@ import im.vector.receiver.VectorUniversalLinkReceiver;
 import im.vector.services.EventStreamService;
 import im.vector.util.BugReporter;
 import im.vector.util.CallsManager;
+import im.vector.util.PreferencesManager;
 import im.vector.util.RoomUtils;
 import im.vector.util.ThemeUtils;
 import im.vector.util.VectorUtils;
@@ -579,6 +581,31 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
         displayCryptoCorruption();
 
         addBadgeEventsListener();
+
+        ignoreBatteryOptimizationsIfNeeded();
+    }
+
+    /**
+     * Make sure the app has permissions to run in background.
+     * This is linked to the "Ignore Battery Optimizations" android setting.
+     */
+    private void ignoreBatteryOptimizationsIfNeeded() {
+        // @TODO: ask it only at the first start (like Riot-iOS)
+
+        // if required by his device android version, the user must allow the app to ignore battery
+        // optimizations so that the app can sync in background
+        if (!PreferencesManager.isIgnoringBatteryOptimizations(this)
+                && !PreferencesManager.didAskUserToIgnoreBatteryOptimizations(this)) {
+
+            // @TODO: Display a popup why the user wants to allow the app to run in background
+            // and to make the app ignore battery optimizations
+
+            PreferencesManager.setDidAskUserToIgnoreBatteryOptimizations(this, true);
+            Intent intent = new Intent();
+            intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+            intent.setData(Uri.parse("package:" + getPackageName()));
+            startActivity(intent);
+        }
     }
 
     @Override

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
+ * Copyright 2018 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -600,7 +600,7 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
 
         if (!gcmMgr.useGCM()) {
             // f-droid does not need the permission.
-            // It is still using the "Listen for events" notification
+            // It is still using the technique of sticky "Listen for events" notification
             return;
         }
 
@@ -623,14 +623,15 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
 
                     Log.d(LOG_TAG, "checkNotificationPrivacySetting: user wants to grant the IgnoreBatteryOptimizations permission");
 
+                    // this is the normal policy on our "Notification Privacy" setting page:
                     // use GCM, share only meta data with it. Then, background sync to fetch message content
                     gcmMgr.setContentSendingAllowed(false);
                     gcmMgr.setBackgroundSyncAllowed(true);
                     gcmMgr.forceSessionsRegistration(null);
 
-                    // display the system permission grant dialog
-                    // if already granted, the system will show not show this dialog.
-                    // note: If the user finally does not grant the permission, gcmMgr.isBackgroundSyncAllowed()
+                    // display the system dialog for granting the IgnoreBatteryOptimizations permission.
+                    // If already granted, the system will not show it.
+                    // Note: If the user finally does not grant the permission, gcmMgr.isBackgroundSyncAllowed()
                     // will return false and low detail notifications will be displayed.
                     Intent intent = new Intent();
                     intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -1134,19 +1134,19 @@ public final class GcmRegistrationManager {
 
     /**
      * Tell if the application can run in background.
-     * It depends on the app settings and the "isIgnoringBatteryOptimizations" permission.
+     * It depends on the app settings and the `IgnoringBatteryOptimizations` permission.
      *
      * @return true if the background sync is allowed
      */
     public boolean isBackgroundSyncAllowed() {
-        // First check if the application has the "run in background" permission
+        // first check if the application has the "run in background" permission.
         // No permission, no background sync
         if (!PreferencesManager.isIgnoringBatteryOptimizations(mContext))
         {
             return false;
         }
 
-        // Then, this depends on the user setting
+        // then, this depends on the user setting
         return getGcmSharedPreferences().getBoolean(PREFS_ALLOW_BACKGROUND_SYNC, true);
     }
 

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -139,9 +139,6 @@ public final class GcmRegistrationManager {
     // 3 states : null not initialized (retrieved by flavor)
     private static Boolean mUseGCM;
 
-    //
-    private boolean mLastBatteryOptimizationStatus;
-
     // pusher rest client
     private Map<String, PushersRestClient> mPushersRestClients = new HashMap<>();
 
@@ -182,7 +179,6 @@ public final class GcmRegistrationManager {
         });
 
         mRegistrationState = getStoredRegistrationState();
-        mLastBatteryOptimizationStatus = PreferencesManager.isIgnoringBatteryOptimizations(mContext);
         mRegistrationToken = getStoredRegistrationToken();
     }
 
@@ -536,8 +532,7 @@ public final class GcmRegistrationManager {
      * @return true if the registration was done with event Id only
      */
     public void onAppResume() {
-        if ((mRegistrationState == RegistrationState.SERVER_REGISTERED) &&
-                (mLastBatteryOptimizationStatus != PreferencesManager.isIgnoringBatteryOptimizations(mContext))) {
+        if (mRegistrationState == RegistrationState.SERVER_REGISTERED) {
             Log.d(LOG_TAG, "## onAppResume() : force the GCM registration");
 
             forceSessionsRegistration(new ThirdPartyRegistrationListener() {

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -1138,27 +1138,27 @@ public final class GcmRegistrationManager {
     }
 
     /**
-     * @TODO
+     * Tell if the application can run in background.
+     * It depends on the app settings and the "isIgnoringBatteryOptimizations" permission.
      *
      * @return true if the background sync is allowed
      */
     public boolean isBackgroundSyncAllowed() {
-        // @TODO: This setting must linked to the Android 6 permission to run in background
-        // ie, no permission, no background sync
+        // First check if the application has the "run in background" permission
+        // No permission, no background sync
+        if (!PreferencesManager.isIgnoringBatteryOptimizations(mContext))
+        {
+            return false;
+        }
+
+        // Then, this depends on the user setting
         return getGcmSharedPreferences().getBoolean(PREFS_ALLOW_BACKGROUND_SYNC, true);
     }
 
     /**
-     * Tell if the application can be restarted in background
-     *
-     * @return true if the application can be restarted in background
-     */
-    public boolean canStartAppInBackground() {
-        return isBackgroundSyncAllowed() || (null != getStoredRegistrationToken());
-    }
-
-    /**
-     * Allow the background sync
+     * Allow the background sync.
+     * Background sync (isBackgroundSyncAllowed) is really enabled if the "isIgnoringBatteryOptimizations"
+     * permission has been granted.
      *
      * @param isAllowed true to allow the background sync.
      */
@@ -1171,6 +1171,15 @@ public final class GcmRegistrationManager {
 
         // when GCM is disabled, enable / disable the "Listen for events" notifications
         CommonActivityUtils.onGcmUpdate(mContext);
+    }
+
+    /**
+     * Tell if the application can be restarted in background
+     *
+     * @return true if the application can be restarted in background
+     */
+    public boolean canStartAppInBackground() {
+        return isBackgroundSyncAllowed() || (null != getStoredRegistrationToken());
     }
 
     /**

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2015 Google Inc. All Rights Reserved.
  * Copyright 2017 Vector Creations Ltd
+ * Copyright 2018 New Vector Ltd
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2015 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
+ * Copyright 2018 New Vector Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -1250,30 +1250,22 @@ public class EventStreamService extends Service {
                 notifiedLine.setSpan(new StyleSpan(android.graphics.Typeface.BOLD), 0, header.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
                 mBackgroundNotificationStrings.add(0, notifiedLine);
-                Notification notification = NotificationUtils.buildMessagesListNotification(context, mBackgroundNotificationStrings, new BingRule(null, null, true, true, true));
-
-                if (null != notification) {
-                    nm.notify(NOTIF_ID_MESSAGES, notification);
-                }
-                else {
-                    Log.e(LOG_TAG, "## onStaticNotifiedEvent() : cannot create a new notification");
-                }
+                getInstance().displayMessagesNotification(mBackgroundNotificationStrings, new BingRule(null, null, true, true, true));
             }
         } else if (0 == unreadMessagesCount) {
             mBackgroundNotificationStrings.clear();
             mLastBackgroundNotificationUnreadCount = 0;
             mLastBackgroundNotificationRoomId = null;
-            dismissMessagesNotification(nm);
+            getInstance().displayMessagesNotification(null, null);
         }
     }
 
     /**
      * Display a list of messages in the messages notification.
      *
-     * @param messages the messages list
+     * @param messages the messages list, null will hide the messages notification.
      * @param rule     the bing rule to use
      */
-    // TODO: Not used?
     private void displayMessagesNotification(final List<CharSequence> messages, final BingRule rule) {
         NotificationUtils.addNotificationChannels(this);
         final NotificationManagerCompat nm = NotificationManagerCompat.from(EventStreamService.this);
@@ -1303,15 +1295,6 @@ public class EventStreamService extends Service {
     }
 
     /**
-     * Dismiss the messages notifications.
-     *
-     * @param nm the notifications manager
-     */
-    static private void dismissMessagesNotification(NotificationManagerCompat nm) {
-        nm.cancel(NOTIF_ID_MESSAGES);
-    }
-
-    /**
      * Refresh the messages notification.
      * Must always be called in getNotificationsHandler() thread.
      */
@@ -1330,7 +1313,7 @@ public class EventStreamService extends Service {
             new Handler(getMainLooper()).post(new Runnable() {
                 @Override
                 public void run() {
-                    dismissMessagesNotification(nm);
+                    displayMessagesNotification(null, null);
                 }
             });
         } else if (refreshNotifiedMessagesList()) {
@@ -1339,7 +1322,7 @@ public class EventStreamService extends Service {
                 new Handler(getMainLooper()).post(new Runnable() {
                     @Override
                     public void run() {
-                        dismissMessagesNotification(nm);
+                        displayMessagesNotification(null, null);
                     }
                 });
             } else {
@@ -1398,11 +1381,11 @@ public class EventStreamService extends Service {
                             if (null != notif) {
                                 nm.notify(NOTIF_ID_MESSAGES, notif);
                             } else {
-                                nm.cancel(NOTIF_ID_MESSAGES);
+                                displayMessagesNotification(null, null);
                             }
                         } else {
                             Log.e(LOG_TAG, "## refreshMessagesNotification() : mNotifiedEventsByRoomId is empty");
-                            dismissMessagesNotification(nm);
+                            displayMessagesNotification(null, null);
                         }
                     }
                 });

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -1291,6 +1291,7 @@ public class EventStreamService extends Service {
                 @Override
                 public void run() {
                     nm.cancel(NOTIF_ID_MESSAGES);
+                    RoomsNotifications.deleteCachedRoomNotifications(VectorApp.getInstance());
                 }
             });
         } else {

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -133,14 +133,14 @@ public class EventStreamService extends Service {
     public enum ForegroundNotificationState {
         // the foreground notification is not displayed
         NONE,
-        // initial sync or the app is resuming in progress
-        // if started, we want the application completes its first sync after startup even in background
+        // initial sync in progress or the app is resuming
+        // once started, we want the application completes its first sync even if it is background meanwhile
         INITIAL_SYNCING,
         // fdroid mode or GCM registration failed
-        // put this service in foreground to keep it in life
+        // put this service in foreground to keep the app in life
         LISTENING_FOR_EVENTS,
         // there is a pending incoming call
-        // we need to continue to sync in background to keep the call signaling up
+        // continue to sync in background to keep the call signaling up
         INCOMING_CALL,
         // a call is in progress
         // same requirement as INCOMING_CALL
@@ -846,8 +846,8 @@ public class EventStreamService extends Service {
     }
 
     /**
-     * Manages the "listen for events" and "synchronising" notifications
-     * @TODO: Refine comments. It does more than that.
+     * Manages the sticky foreground notification.
+     * It display the background state of the app ("Listen for events", "synchronising", ...)
      */
     public void refreshStatusNotification() {
         Log.d(LOG_TAG, "## refreshStatusNotification from state " + mForegroundNotificationState);
@@ -1256,8 +1256,7 @@ public class EventStreamService extends Service {
                     nm.notify(NOTIF_ID_MESSAGES, notification);
                 }
                 else {
-                   // TODO: Really?
-                   dismissMessagesNotification(nm);
+                    Log.e(LOG_TAG, "## onStaticNotifiedEvent() : cannot create a new notification");
                 }
             }
         } else if (0 == unreadMessagesCount) {
@@ -1274,6 +1273,7 @@ public class EventStreamService extends Service {
      * @param messages the messages list
      * @param rule     the bing rule to use
      */
+    // TODO: Not used?
     private void displayMessagesNotification(final List<CharSequence> messages, final BingRule rule) {
         NotificationUtils.addNotificationChannels(this);
         final NotificationManagerCompat nm = NotificationManagerCompat.from(EventStreamService.this);

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -841,7 +841,7 @@ public class EventStreamService extends Service {
 
     /**
      * Manages the sticky foreground notification.
-     * It display the background state of the app ("Listen for events", "synchronising", ...)
+     * It displays the background state of the app ("Listen for events", "synchronising", ...)
      */
     public void refreshForegroundNotification() {
         Log.d(LOG_TAG, "## refreshForegroundNotification from state " + mForegroundNotificationState);

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2016 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
+ * Copyright 2018 New Vector Ltd
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -133,6 +133,8 @@ public class PreferencesManager {
 
     private static final String SETTINGS_DISPLAY_ALL_EVENTS_KEY = "SETTINGS_DISPLAY_ALL_EVENTS_KEY";
 
+    private static final String DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY = "DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY";
+
     private static final int MEDIA_SAVING_3_DAYS = 0;
     private static final int MEDIA_SAVING_1_WEEK = 1;
     private static final int MEDIA_SAVING_1_MONTH = 2;
@@ -204,18 +206,44 @@ public class PreferencesManager {
     }
 
     /**
-     * Tells if the battery optimisations are ignored for this application.
+     * Tells if we have already asked the user to disable battery optimisations on android >= M devices.
      *
      * @param context the context
-     * @return true if the battery optimisations are ignored.
+     * @return true if it was already requested
+     */
+    public static boolean didAskUserToIgnoreBatteryOptimizations(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY, false);
+    }
+
+    /**
+     * Mark as requested the question to disable battery optimisations.
+     *
+     * @param context the context
+     */
+    public static void setDidAskUserToIgnoreBatteryOptimizations(Context context, boolean asked) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putBoolean(DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY, asked);
+        editor.commit();
+    }
+
+    /**
+     * Tells if the application ignores battery optimizations.
+     *
+     * Ignoring them allows the app to run in background to make background sync with the homeserver.
+     * This user option appears on Android M but Android O enforces its usage and kills apps not
+     * authorised by the user to run in background.
+     *
+     * @param context the context
+     * @return true if battery optimisations are ignored
      */
     @SuppressLint("NewApi")
-    public static boolean useBatteryOptimisation(Context context) {
+    public static boolean isIgnoringBatteryOptimizations(Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return !((PowerManager) context.getSystemService(context.POWER_SERVICE)).isIgnoringBatteryOptimizations(context.getPackageName());
+            return ((PowerManager) context.getSystemService(context.POWER_SERVICE)).isIgnoringBatteryOptimizations(context.getPackageName());
         }
-
-        return false;
+        // do not ask before Android M, the setting did not exist
+        return true;
     }
 
     /**

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -242,7 +242,8 @@ public class PreferencesManager {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             return ((PowerManager) context.getSystemService(context.POWER_SERVICE)).isIgnoringBatteryOptimizations(context.getPackageName());
         }
-        // do not ask before Android M, the setting did not exist
+
+        // no issue before Android M, battery optimisations did not exist
         return true;
     }
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -589,6 +589,12 @@
     <string name="settings_disable_markdown">Disable markdown formatting when sending</string>
     <string name="settings_vibrate_on_mention">Vibrate when mentioning</string>
 
+    <!-- startup -->
+    <string name="startup_notification_privacy_title">Notification Privacy</string>
+    <string name="startup_notification_privacy_message">Riot can run in the background to manage your notifications securely and privately (this might affect battery usage).</string>
+    <string name="startup_notification_privacy_button_grant">Grant permission</string>
+    <string name="startup_notification_privacy_button_other">Choose another option</string>
+
     <!-- analytics -->
     <string name="settings_analytics">Analytics</string>
     <string name="settings_opt_out_of_analytics">Opt out of analytics</string>


### PR DESCRIPTION
#2130

On GCM, come back to the use of the IgnoreBatteryOptimization permission so that bg sync can work on Android >=8. We ask the permission after login with a popup explaining why the app needs it. The "Notification Privacy" setting page is coming.
The foreground/sticky notification still appears for the initial sync and call signalling management **but** not for messages.

On F-Droid, we have 2 notifications: one (removable) for the messages and the foreground/sticky notification for bg tasks: "Listen For Events", the initial sync and call management.
