### PR TITLE
remove # before build version

### DIFF
--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -235,7 +235,7 @@ public class Matrix {
         String buildNumber = mAppContext.getResources().getString(R.string.build_number);
 
         if ((useBuildNumber) && !TextUtils.equals(buildNumber, "0")) {
-            gitVersion = "#" + buildNumber;
+            gitVersion = "b" + buildNumber;
             longformat = false;
         }
 


### PR DESCRIPTION
Every time when people refer to a riot-build they use the string
as provided in the app. This leads to a trigger of the github bot
which thinks that the version string refers to a issue/ pull request

To avoid this we replace the hashtag with a b so we now get a version
like G-b1234. This is currently not used anywhere as trigger (AFAIK)
so the room should not be polluted with content of overactive bots

Signed-Off-by: Matthias Kesler <krombel@krombel.de>