### PR TITLE
Fix formatting in AUTHORS.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,5 +40,5 @@ Chris Tarazi <tarazichris at gmail.com>
 Safa AlFulaij <safa1996alfulaij at gmail.com>
  * PR #1934: Fix some plural messages.
 
- Isa Cichon <isa4 at posteo.net>
+Isa Cichon <isa4 at posteo.net>
  *  Add spacing to device keys


### PR DESCRIPTION
I made an error while adding myself to AUTHORS.rst and had a space before my name, so it wasn't displayed correctly.  I'm very sorry about this.