### PR TITLE
Send voice message to a room

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changes in Riot 0.8.11 (2018-XX-XX)
 
 Features:
  - Re-request keys manually for encrypted events (#2319)
+ - Add option to send voice message to a room, using a third application to record message.
+   To enable in the Labs settings (PR #1762)
 
 Improvements:
  - Add spacing to device keys (#2314)

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -2270,7 +2270,6 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
     /**
      * Launch audio recorder intent
      */
-    @SuppressLint("NewApi")
     private void launchAudioRecorderIntent() {
         enableActionBarHeader(HIDE_ACTION_BAR_HEADER);
 
@@ -2288,7 +2287,6 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
     /**
      * Launch the files selection intent
      */
-    @SuppressLint("NewApi")
     private void launchFileSelectionIntent() {
         enableActionBarHeader(HIDE_ACTION_BAR_HEADER);
 

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -127,6 +127,8 @@ public class PreferencesManager {
 
     private static final String SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY = "SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY";
 
+    private static final String SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY = "SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY";
+
     public static final String SETTINGS_SHOW_URL_PREVIEW_KEY = "SETTINGS_SHOW_URL_PREVIEW_KEY";
 
     private static final String SETTINGS_VIBRATE_ON_MENTION_KEY = "SETTINGS_VIBRATE_ON_MENTION_KEY";
@@ -292,6 +294,16 @@ public class PreferencesManager {
      */
     public static boolean useNativeCamera(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY, false);
+    }
+
+    /**
+     * Tells if the send voice feature is enabled.
+     *
+     * @param context the context
+     * @return true if the send voice feature is enabled.
+     */
+    public static boolean isSendVoiceFeatureEnabled(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY, false);
     }
 
     /**

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -180,6 +180,10 @@
     <!-- No sticker application dialog -->
     <string name="no_sticker_application_dialog_content">You don\'t currently have any stickerpacks enabled.\n\nAdd some now?</string>
 
+    <!-- External application -->
+    <string name="go_on_with">go on with…</string>
+    <string name="error_no_external_application_found">Sorry, no external application has been found to complete this action.</string>
+
     <!-- Authentication -->
     <string name="auth_login">Log in</string>
     <string name="auth_register">Register</string>
@@ -910,6 +914,7 @@
     <string name="settings_labs_matrix_apps">Matrix Apps</string>
     <string name="room_add_matrix_apps">Add Matrix apps</string>
     <string name="settings_labs_native_camera">Use native camera</string>
+    <string name="settings_labs_enable_send_voice">Send voice message (requires a third party application to record voice messages)</string>
 
     <!-- share keys -->
     <string name="you_added_a_new_device">You added a new device \'%s\', which is requesting encryption keys.</string>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -271,6 +271,10 @@
             android:key="SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY"
             android:title="@string/settings_labs_native_camera" />
 
+        <im.vector.preference.VectorSwitchPreference
+            android:key="SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY"
+            android:title="@string/settings_labs_enable_send_voice" />
+
     </im.vector.preference.VectorPreferenceCategory>
 
     <im.vector.preference.VectorDividerCategory />


### PR DESCRIPTION
Add option to send voice message to a room, using a third application to record the message.
- An application able to handle intent action MediaStore.Audio.Media.RECORD_SOUND_ACTION has to be installed on the device
- Audio message are seen has files, so they have to be downloaded to be played.
- Riot web does not seem to be able to read m4a audio format
- This feature has to be enabled in the Labs settings, and is supposed to be removed when audio message will be supported natively by the matrix protocol

Credit comes to @harish2704 for the first PR (#1762)