### PR TITLE
allow overwriting DEFAULT_PUSHER_URL via Settings store

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Changes in Riot 0.8.13 (2018-XX-XX)
 ===================================================
 
 Features:
+ - allow overwriting DEFAULT_PUSHER_URL via Settings store (#2424)
  -
 
 Improvements:

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -67,6 +67,7 @@ public final class GcmRegistrationManager {
     private static final String PREFS_PUSHER_REGISTRATION_TOKEN_KEY_FCM = "PREFS_PUSHER_REGISTRATION_TOKEN_KEY_FCM";
     private static final String PREFS_PUSHER_REGISTRATION_TOKEN_KEY = "PREFS_PUSHER_REGISTRATION_TOKEN_KEY";
     private static final String PREFS_PUSHER_REGISTRATION_STATUS = "PREFS_PUSHER_REGISTRATION_STATUS";
+    private static final String PREFS_PUSHER_PUSHER_URL = "PREFS_PUSHER_PUSHER_URL";
 
     private static final String PREFS_SYNC_TIMEOUT = "GcmRegistrationManager.PREFS_SYNC_TIMEOUT";
     private static final String PREFS_SYNC_DELAY = "GcmRegistrationManager.PREFS_SYNC_DELAY";
@@ -602,7 +603,7 @@ public final class GcmRegistrationManager {
         getPushersRestClient(session)
                 .addHttpPusher(mRegistrationToken, DEFAULT_PUSHER_APP_ID, computePushTag(session),
                         mPusherLang, mPusherAppName, mBasePusherDeviceName,
-                        DEFAULT_PUSHER_URL, append, eventIdOnlyPushes, new ApiCallback<Void>() {
+                        getPusherUrl(), append, eventIdOnlyPushes, new ApiCallback<Void>() {
                             @Override
                             public void onSuccess(Void info) {
                                 Log.d(LOG_TAG, "registerToThirdPartyServer succeeded");
@@ -974,7 +975,7 @@ public final class GcmRegistrationManager {
         getPushersRestClient(session)
                 .removeHttpPusher(mRegistrationToken, DEFAULT_PUSHER_APP_ID, computePushTag(session),
                         mPusherLang, mPusherAppName, mBasePusherDeviceName,
-                        DEFAULT_PUSHER_URL, new ApiCallback<Void>() {
+                        getPusherUrl(), new ApiCallback<Void>() {
                             @Override
                             public void onSuccess(Void info) {
                                 Log.d(LOG_TAG, "unregisterSession succeeded");
@@ -1129,6 +1130,21 @@ public final class GcmRegistrationManager {
             }
         }
         return mUseGCM;
+    }
+
+    /**
+     * Get Pusher Url
+     * @return
+     */
+    protected String getPusherUrl(){
+        // Stetho only allows setting values which are already in the store
+        if (!getGcmSharedPreferences().contains(PREFS_PUSHER_PUSHER_URL)) {
+            getGcmSharedPreferences()
+                    .edit()
+                    .putString(PREFS_PUSHER_PUSHER_URL, DEFAULT_PUSHER_URL)
+                    .apply();
+        }
+        return getGcmSharedPreferences().getString(PREFS_PUSHER_PUSHER_URL, DEFAULT_PUSHER_URL);
     }
 
     /**


### PR DESCRIPTION
To experiment with push services I found it useful to overwrite the
push gateway directly on the device. For this the already integrated
"Stheto" framework is used.

A future plan might be to implement some UI for that but for
DEV-purposes that is enough.

Signed-Off-By: Matthias Kesler <krombel@krombel.de>