### PR TITLE
Messages with code blocks show other HTML as plain text (#2280)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Bugfix:
  - Fix issue when selecting sound for notifications in the settings
  - Fix issue when changing device name in the settings (#2416)
  - Fix issue on verifying device, update the wording of the description message (#1067)
+ - Messages with code blocks show other HTML as plain text (#2280)
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -1336,14 +1336,11 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
                 String minusTags = block
                         .substring(VectorMessagesAdapterHelper.START_FENCED_BLOCK.length(),
                                 block.length() - VectorMessagesAdapterHelper.END_FENCED_BLOCK.length())
-                        .replace("\n", "<br/>")
-                        .replace(" ", "&nbsp;");
+                        .trim();
                 final View blockView = mLayoutInflater.inflate(R.layout.adapter_item_vector_message_code_block, null);
                 final TextView tv = blockView.findViewById(R.id.messagesAdapter_body);
 
-                CharSequence sequence = mHelper.convertToHtml(minusTags);
-
-                tv.setText(sequence);
+                tv.setText(minusTags);
 
                 mHelper.highlightFencedCode(tv);
 
@@ -1359,14 +1356,22 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
 
                 String block2 = block;
                 if (TextUtils.equals(Message.FORMAT_MATRIX_HTML, message.format)) {
-                    String sanitased = mHelper.getSanitisedHtml(block2);
+                    // Preserve space and new lines
+                    block2 = block2
+                            .trim()
+                            .replace("\n", "<br/>")
+                            .replace(" ", "&nbsp;");
 
-                    if (sanitased != null) {
-                        block2 = sanitased;
+                    String sanitized = mHelper.getSanitisedHtml(block2);
+
+                    if (sanitized != null) {
+                        block2 = sanitized;
                     }
                 }
 
-                CharSequence strBuilder = mHelper.highlightPattern(new SpannableString(block2),
+                CharSequence sequence = mHelper.convertToHtml(block2);
+
+                CharSequence strBuilder = mHelper.highlightPattern(new SpannableString(sequence),
                         mPattern,
                         mBackgroundColorSpan,
                         shouldHighlighted);


### PR DESCRIPTION
I've done several tests, it seems ok, but I'll be more confident if we got plenty of unitary tests...

Fix #2280 