### PR TITLE
Support external keyboard

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,6 @@ Features:
  - Telemetry to report incidence of UISIs (#2330)
  - Add a previewer for previewing media before sending it into the room (#1742|#2445)
  - Implements ReplyTo feature (#2390)
- - Add a setting to allow the user to use the enter key on his keyboard to send message instead of to add a new line (#394)
  - Support Room Versioning (#2441)
 
 Improvements:
@@ -16,6 +15,7 @@ Improvements:
  - Improve the display of the sources of the message in the dialog (#2348)
  - Improve the display of the buttons and the reason in the room preview (#2352)
  - In the flair section on settings, notify the user when he has no flair (#2430)
+ - Support external keyboard to send messages for recent devices (#220, #1279)
 
 Other changes:
  - Remove dependency to `android-gif-drawable` lib and use Glide to animate logo on Splashscreen (#2421)

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -727,12 +727,9 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
                     sendTextMessage();
                     return true;
                 }
-
                 return false;
             }
         });
-
-        manageKeyboardOptionsToSendMessage();
 
         mEditText.setAddColonOnFirstItem(true);
 
@@ -2322,34 +2319,6 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
             }
         } else {
             Log.w(LOG_TAG, "## onRequestPermissionsResult(): Unknown requestCode =" + aRequestCode);
-        }
-    }
-
-    /**
-     * The user can use enter key on his soft keyboard to add a new line or to send message
-     * depending on the settings he has chosen.
-     */
-    private void manageKeyboardOptionsToSendMessage() {
-        if (PreferencesManager.useEnterKeyToSendMessage(this)) {
-            mEditText.setImeOptions(EditorInfo.IME_ACTION_SEND);
-            mEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
-                @Override
-                public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                    if (actionId  == EditorInfo.IME_ACTION_SEND) {
-                        sendTextMessage();
-                        return true;
-                    }
-                    return false;
-                }
-            });
-        } else {
-            mEditText.setImeOptions(EditorInfo.IME_ACTION_UNSPECIFIED);
-            mEditText.setInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE);
-            mEditText.setOnKeyListener(null);
-            mEditText.setSingleLine(false);
-            if (mEditText.getText().length() > 0) {
-                mEditText.setText("\n");
-            }
         }
     }
 

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
@@ -598,18 +598,6 @@ class VectorSettingsPreferencesFragment : PreferenceFragment(), SharedPreference
             }
         }
 
-        // Others
-
-        (findPreference(PreferencesManager.SETTINGS_SEND_MESSAGE_ENTER_KEY) as CheckBoxPreference).let {
-            it.isChecked = PreferencesManager.useEnterKeyToSendMessage(appContext)
-
-            it.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { preference, newValue ->
-                PreferencesManager.setUseEnterKeyToSendMessage(appContext, newValue as Boolean)
-                true
-            }
-        }
-
-
         // preference to start the App info screen, to facilitate App permissions access
         findPreference(APP_INFO_LINK_PREFERENCE_KEY)
                 .onPreferenceClickListener = Preference.OnPreferenceClickListener {

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -116,7 +116,6 @@ public class PreferencesManager {
     private static final String SETTINGS_PIN_UNREAD_MESSAGES_PREFERENCE_KEY = "SETTINGS_PIN_UNREAD_MESSAGES_PREFERENCE_KEY";
     private static final String SETTINGS_PIN_MISSED_NOTIFICATIONS_PREFERENCE_KEY = "SETTINGS_PIN_MISSED_NOTIFICATIONS_PREFERENCE_KEY";
 
-    public static final String SETTINGS_SEND_MESSAGE_ENTER_KEY = "SETTINGS_SEND_MESSAGE_ENTER_KEY";
     public static final String SETTINGS_DATA_SAVE_MODE_PREFERENCE_KEY = "SETTINGS_DATA_SAVE_MODE_PREFERENCE_KEY";
     public static final String SETTINGS_START_ON_BOOT_PREFERENCE_KEY = "SETTINGS_START_ON_BOOT_PREFERENCE_KEY";
     public static final String SETTINGS_INTERFACE_TEXT_SIZE_KEY = "SETTINGS_INTERFACE_TEXT_SIZE_KEY";
@@ -157,7 +156,6 @@ public class PreferencesManager {
 
     // some preferences keys must be kept after a logout
     private static final List<String> mKeysToKeepAfterLogout = Arrays.asList(
-            SETTINGS_SEND_MESSAGE_ENTER_KEY,
             SETTINGS_HIDE_READ_RECEIPTS_KEY,
             SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY,
             SETTINGS_12_24_TIMESTAMPS_KEY,
@@ -726,29 +724,6 @@ public class PreferencesManager {
         PreferenceManager.getDefaultSharedPreferences(context)
                 .edit()
                 .putBoolean(SETTINGS_USE_RAGE_SHAKE_KEY, isEnabled)
-                .apply();
-    }
-
-    /**
-     * Tells if the user want to use enter key to send messages
-     *
-     * @param context the context
-     * @return true if the enter key is activated to send message
-     */
-    public static boolean useEnterKeyToSendMessage(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SEND_MESSAGE_ENTER_KEY, false);
-    }
-
-    /**
-     * Update the enter key to send message status.
-     *
-     * @param context   the context
-     * @param isEnabled true to enable to press enter key to send message
-     */
-    public static void setUseEnterKeyToSendMessage(Context context, boolean isEnabled) {
-        PreferenceManager.getDefaultSharedPreferences(context)
-                .edit()
-                .putBoolean(SETTINGS_SEND_MESSAGE_ENTER_KEY, isEnabled)
                 .apply();
     }
 

--- a/vector/src/main/res/layout/activity_vector_room.xml
+++ b/vector/src/main/res/layout/activity_vector_room.xml
@@ -263,7 +263,7 @@
                         android:background="@android:color/transparent"
                         android:dropDownAnchor="@+id/room_sending_message_layout"
                         android:hint="@string/room_message_placeholder_not_encrypted"
-                        android:inputType="textCapSentences"
+                        android:inputType="textCapSentences|textMultiLine"
                         android:maxHeight="160dp"
                         android:textColor="?attr/riot_primary_text_color"
                         android:textColorHint="?attr/default_text_hint_color"

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -106,11 +106,6 @@
             android:title="@string/settings_preview_media_before_sending"
             android:key="SETTINGS_PREVIEW_MEDIA_BEFORE_SENDING_KEY"/>
 
-        <im.vector.preference.VectorSwitchPreference
-            android:defaultValue="false"
-            android:key="SETTINGS_SEND_MESSAGE_ENTER_KEY"
-            android:title="@string/settings_labs_keyboard_options_to_send_message" />
-
     </PreferenceCategory>
 
     <im.vector.preference.VectorDividerCategory />


### PR DESCRIPTION
Related to #220 and #1279 
- remove the option to send a message with the entry key of the soft keyboard (this feature isn't relevant because the current code allows us to send a message or to add a new line).
- keep the current code that allows to send a message with the enter key of an external keyboard and return to the line with Shift + Enter (for recent devices)

