### PR TITLE
Feature/fix 2409

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Bugfix:
  - Remove last traces of Firebase analytics (#2481)
  - code blocks are escaped and therefore hard readable (#2484)
  - Restore the navigation of the back button in the public rooms preview header (#2473)
+ - Fix issue on preference screen: device lists was not displayed (#2409)
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/LoginHandler.java
+++ b/vector/src/main/java/im/vector/LoginHandler.java
@@ -47,7 +47,8 @@ public class LoginHandler {
      */
     private void onRegistrationDone(Context appCtx,
                                     HomeServerConnectionConfig hsConfig,
-                                    Credentials credentials, SimpleApiCallback<HomeServerConnectionConfig> callback) {
+                                    Credentials credentials,
+                                    ApiCallback<HomeServerConnectionConfig> callback) {
         // sanity check - GA issue
         if (TextUtils.isEmpty(credentials.userId)) {
             callback.onMatrixError(new MatrixError(MatrixError.FORBIDDEN, "No user id"));
@@ -89,7 +90,7 @@ public class LoginHandler {
                       final String phoneNumber,
                       final String phoneNumberCountry,
                       final String password,
-                      final SimpleApiCallback<HomeServerConnectionConfig> callback) {
+                      final ApiCallback<HomeServerConnectionConfig> callback) {
         final Context appCtx = ctx.getApplicationContext();
 
         callLogin(ctx, hsConfig, username, phoneNumber, phoneNumberCountry, password, new UnrecognizedCertApiCallback<Credentials>(hsConfig, callback) {
@@ -121,7 +122,7 @@ public class LoginHandler {
                            final String phoneNumber,
                            final String phoneNumberCountry,
                            final String password,
-                           final SimpleApiCallback<Credentials> callback) {
+                           final ApiCallback<Credentials> callback) {
         LoginRestClient client = new LoginRestClient(hsConfig);
         String deviceName = ctx.getString(R.string.login_mobile_device);
 
@@ -145,7 +146,7 @@ public class LoginHandler {
      * @param hsConfig the home server config.
      * @param callback the supported flows list callback.
      */
-    public void getSupportedLoginFlows(Context ctx, final HomeServerConnectionConfig hsConfig, final SimpleApiCallback<List<LoginFlow>> callback) {
+    public void getSupportedLoginFlows(Context ctx, final HomeServerConnectionConfig hsConfig, final ApiCallback<List<LoginFlow>> callback) {
         final Context appCtx = ctx.getApplicationContext();
         LoginRestClient client = new LoginRestClient(hsConfig);
 
@@ -166,7 +167,7 @@ public class LoginHandler {
      */
     public void getSupportedRegistrationFlows(Context ctx,
                                               final HomeServerConnectionConfig hsConfig,
-                                              final SimpleApiCallback<HomeServerConnectionConfig> callback) {
+                                              final ApiCallback<HomeServerConnectionConfig> callback) {
         register(ctx, hsConfig, new RegistrationParams(), callback);
     }
 
@@ -180,7 +181,7 @@ public class LoginHandler {
     private void register(Context ctx,
                           final HomeServerConnectionConfig hsConfig,
                           final RegistrationParams params,
-                          final SimpleApiCallback<HomeServerConnectionConfig> callback) {
+                          final ApiCallback<HomeServerConnectionConfig> callback) {
         final Context appCtx = ctx.getApplicationContext();
         LoginRestClient client = new LoginRestClient(hsConfig);
 

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -515,7 +515,7 @@ public class Matrix {
     public synchronized void clearSession(final Context context,
                                           final MXSession session,
                                           final boolean clearCredentials,
-                                          final SimpleApiCallback<Void> aCallback) {
+                                          final ApiCallback<Void> aCallback) {
         if (!session.isAlive()) {
             Log.e(LOG_TAG, "## clearSession() " + session.getMyUserId() + " is already released");
             return;
@@ -529,7 +529,7 @@ public class Matrix {
 
         session.getDataHandler().removeListener(mLiveEventListener);
 
-        SimpleApiCallback<Void> callback = new SimpleApiCallback<Void>() {
+        ApiCallback<Void> callback = new SimpleApiCallback<Void>() {
             @Override
             public void onSuccess(Void info) {
                 VectorApp.removeSyncingSession(session);

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -144,7 +144,7 @@ public class CommonActivityUtils {
      * @param clearCredentials true to clear the credentials
      * @param callback         the asynchronous callback
      */
-    public static void logout(Context context, List<MXSession> sessions, boolean clearCredentials, final SimpleApiCallback<Void> callback) {
+    public static void logout(Context context, List<MXSession> sessions, boolean clearCredentials, final ApiCallback<Void> callback) {
         logout(context, sessions.iterator(), clearCredentials, callback);
     }
 
@@ -159,7 +159,7 @@ public class CommonActivityUtils {
     private static void logout(final Context context,
                                final Iterator<MXSession> sessions,
                                final boolean clearCredentials,
-                               final SimpleApiCallback<Void> callback) {
+                               final ApiCallback<Void> callback) {
         if (!sessions.hasNext()) {
             if (null != callback) {
                 callback.onSuccess(null);
@@ -1591,7 +1591,7 @@ public class CommonActivityUtils {
                                               final File srcFile,
                                               final String filename,
                                               final String mimeType,
-                                              final SimpleApiCallback<String> callback) {
+                                              final ApiCallback<String> callback) {
         saveFileInto(srcFile, Environment.DIRECTORY_DOWNLOADS, filename, new ApiCallback<String>() {
             @Override
             public void onSuccess(String fullFilePath) {

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -1632,7 +1632,7 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
      * @param onSuccessCallback the success callback
      * @return the asynchronous callback
      */
-    private ApiCallback<Void> createForgetLeaveCallback(final String roomId, final SimpleApiCallback<Void> onSuccessCallback) {
+    private ApiCallback<Void> createForgetLeaveCallback(final String roomId, final ApiCallback<Void> onSuccessCallback) {
         return new ApiCallback<Void>() {
             @Override
             public void onSuccess(Void info) {
@@ -1678,7 +1678,7 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
      * @param roomId            the room id
      * @param onSuccessCallback the success asynchronous callback
      */
-    public void onForgetRoom(final String roomId, final SimpleApiCallback<Void> onSuccessCallback) {
+    public void onForgetRoom(final String roomId, final ApiCallback<Void> onSuccessCallback) {
         Room room = mSession.getDataHandler().getRoom(roomId);
 
         if (null != room) {
@@ -1693,7 +1693,7 @@ public class VectorHomeActivity extends RiotAppCompatActivity implements SearchV
      * @param roomId            the room id
      * @param onSuccessCallback the success asynchronous callback
      */
-    public void onRejectInvitation(final String roomId, final SimpleApiCallback<Void> onSuccessCallback) {
+    public void onRejectInvitation(final String roomId, final ApiCallback<Void> onSuccessCallback) {
         Room room = mSession.getDataHandler().getRoom(roomId);
 
         if (null != room) {

--- a/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
@@ -353,7 +353,7 @@ public class VectorRoomSettingsFragment extends PreferenceFragment implements Sh
         });
 
         // display the room Id.
-        EditTextPreference roomInternalIdPreference = (EditTextPreference) findPreference(PREF_KEY_ROOM_INTERNAL_ID);
+        Preference roomInternalIdPreference = findPreference(PREF_KEY_ROOM_INTERNAL_ID);
         if (null != roomInternalIdPreference) {
             roomInternalIdPreference.setSummary(mRoom.getRoomId());
 
@@ -367,7 +367,7 @@ public class VectorRoomSettingsFragment extends PreferenceFragment implements Sh
         }
 
         // leave room
-        EditTextPreference leaveRoomPreference = (EditTextPreference) findPreference(PREF_KEY_ROOM_LEAVE);
+        Preference leaveRoomPreference = findPreference(PREF_KEY_ROOM_LEAVE);
 
         if (null != leaveRoomPreference) {
             leaveRoomPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {

--- a/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
@@ -1854,7 +1854,7 @@ public class VectorRoomSettingsFragment extends PreferenceFragment implements Sh
                         @Override
                         public void onSuccess(Boolean status) {
                             if (sendToUnverifiedDevicesPref.isChecked() != status) {
-                                SimpleApiCallback<Void> callback = new SimpleApiCallback<Void>() {
+                                ApiCallback<Void> callback = new SimpleApiCallback<Void>() {
                                     @Override
                                     public void onSuccess(Void info) {
                                     }

--- a/vector/src/main/java/im/vector/preference/VectorCustomActionEditTextPreference.java
+++ b/vector/src/main/java/im/vector/preference/VectorCustomActionEditTextPreference.java
@@ -18,7 +18,6 @@ package im.vector.preference;
 
 import android.content.Context;
 import android.graphics.Typeface;
-import android.preference.EditTextPreference;
 import android.preference.Preference;
 import android.util.AttributeSet;
 
@@ -28,10 +27,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-// create an EditTextPreference with a dedicated click/long click methods.
+// create a Preference with a dedicated click/long click methods.
 // Android displays by an edit text dialog by default
 // With this class, a custom behaviour can be designed.
-public class VectorCustomActionEditTextPreference extends EditTextPreference {
+// TODO Rename to VectorLongClickablePreference in Sprint 14 (September 2018)
+public class VectorCustomActionEditTextPreference extends Preference {
     private static final String LOG_TAG = VectorCustomActionEditTextPreference.class.getSimpleName();
 
     /**

--- a/vector/src/main/java/im/vector/util/GroupUtils.java
+++ b/vector/src/main/java/im/vector/util/GroupUtils.java
@@ -143,7 +143,7 @@ public class GroupUtils {
      * @param session      the session
      * @param groupRoom    the group room
      */
-    public static void openGroupRoom(final Activity fromActivity, final MXSession session, final GroupRoom groupRoom, final SimpleApiCallback<Void> callback) {
+    public static void openGroupRoom(final Activity fromActivity, final MXSession session, final GroupRoom groupRoom, final ApiCallback<Void> callback) {
         Room room = session.getDataHandler().getStore().getRoom(groupRoom.roomId);
 
         if ((null == room) || (null == room.getMember(session.getMyUserId()))) {

--- a/vector/src/main/java/im/vector/util/VectorUtils.java
+++ b/vector/src/main/java/im/vector/util/VectorUtils.java
@@ -900,7 +900,7 @@ public class VectorUtils {
     public static String getUserOnlineStatus(final Context context,
                                              final MXSession session,
                                              final String userId,
-                                             final SimpleApiCallback<Void> refreshCallback) {
+                                             final ApiCallback<Void> refreshCallback) {
         // sanity checks
         if ((null == session) || (null == userId)) {
             return null;


### PR DESCRIPTION
 Fix #2409: VectorCustomActionEditTextPreference are never used as an EditTextPrefence

So it now just extends Preference, so it avoid trying to cast a stored Boolean from the Prefs (why it has been stored is a mystery) to a String to display the EditText value

Main settings and Room settings (who are both using VectorCustomActionEditTextPreference) has been tested Ok

This PR also contains some cleanup