### PR TITLE
Don't fetch previews from server when URL previews are disabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Features:
  -
 
 Improvements:
- -
+ - URL previews are no longer requested from the server when displaying URL previews is disabled (PR #2514)
 
 Other changes:
  - Upgrade olm-sdk.aar from version 2.2.2 to version 2.3.0

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -1219,7 +1219,7 @@ class VectorMessagesAdapterHelper {
             final String downloadKey = url.hashCode() + "---";
             String displayKey = url + "<----->" + id;
 
-            if (!this.mSession.isURLPreviewEnabled()) {
+            if (!mSession.isURLPreviewEnabled()) {
                 if (!mUrlsPreviews.containsKey(downloadKey)) {
                     mUrlsPreviews.put(downloadKey, null);
                     mAdapter.notifyDataSetChanged();

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -1219,7 +1219,12 @@ class VectorMessagesAdapterHelper {
             final String downloadKey = url.hashCode() + "---";
             String displayKey = url + "<----->" + id;
 
-            if (UrlPreviewView.Companion.didUrlPreviewDismiss(displayKey)) {
+            if (!this.mSession.isURLPreviewEnabled()) {
+                if(!mUrlsPreviews.containsKey(downloadKey)) {
+                    mUrlsPreviews.put(downloadKey, null);
+                    mAdapter.notifyDataSetChanged();
+                }
+            } else if (UrlPreviewView.Companion.didUrlPreviewDismiss(displayKey)) {
                 Log.d(LOG_TAG, "## manageURLPreviews() : " + displayKey + " has been dismissed");
             } else if (mPendingUrls.contains(url)) {
                 // please wait

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -1220,7 +1220,7 @@ class VectorMessagesAdapterHelper {
             String displayKey = url + "<----->" + id;
 
             if (!this.mSession.isURLPreviewEnabled()) {
-                if(!mUrlsPreviews.containsKey(downloadKey)) {
+                if (!mUrlsPreviews.containsKey(downloadKey)) {
                     mUrlsPreviews.put(downloadKey, null);
                     mAdapter.notifyDataSetChanged();
                 }


### PR DESCRIPTION
Currently, the client will request the URL preview from the server even when displaying URL previews is disabled. This leads to the contents of E2E-encrypted chats being leaked to the homeserver without the ability to prevent this on the client.

This change sets the URLPreview to null in manageURLPreviews when URL previews are disabled in the session. Missing previews will be fetched when the switch is re-enabled later.