### PR TITLE
fix room details file fragment position after back paginate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfix:
  - Status.im backgrounds, header, buttons, and missing items (#2672)
  - Fix Permalinks and registration issue (#2689)
  - Mention from read receipts list doesn't work (#656)
+ - Fix issue when scrolling file list in room details (#2702)
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/fragments/VectorSearchRoomFilesListFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSearchRoomFilesListFragment.java
@@ -197,8 +197,6 @@ public class VectorSearchRoomFilesListFragment extends VectorSearchRoomsFilesLis
         }
 
         mIsBackPaginating = true;
-
-        final int firstPos = mMessageListView.getFirstVisiblePosition();
         final int countBeforeUpdate = mAdapter.getCount();
 
         // if there is no item in the adapter
@@ -233,7 +231,7 @@ public class VectorSearchRoomFilesListFragment extends VectorSearchRoomsFilesLis
 
                                     // do not use count because some messages are not displayed
                                     // so we compute the new pos
-                                    mMessageListView.setSelection(firstPos + (mAdapter.getCount() - countBeforeUpdate));
+                                    mMessageListView.setSelection(mMessageListView.getFirstVisiblePosition() + (mAdapter.getCount() - countBeforeUpdate));
 
                                     mIsBackPaginating = false;
 


### PR DESCRIPTION
I am going to break up my other PR into several smaller ones. This fixes an issue where the adapter will jump to an incorrect position because a certain variable is assigned too early.