### PR TITLE
modify some settings and update PreferencesManager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Features:
  -
 
 Improvements:
- -
+ - Remove double negations from settings and update descriptions (#2723)
 
 Other changes:
  -

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -2075,7 +2075,7 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
      */
     private void handleTypingNotification(boolean isTyping) {
         // the typing notifications are disabled ?
-        if (PreferencesManager.dontSendTypingNotifs(this)) {
+        if (!PreferencesManager.sendTypingNotifs(this)) {
             Log.d(LOG_TAG, "##handleTypingNotification() : the typing notifications are disabled");
             return;
         }

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -216,7 +216,7 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
 
     // custom settings
     private final boolean mAlwaysShowTimeStamps;
-    private final boolean mHideReadReceipts;
+    private final boolean mShowReadReceipts;
 
     // Key is member id.
     private final Map<String, RoomMember> mLiveRoomMembers = new HashMap<>();
@@ -375,7 +375,7 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
         mLocale = VectorLocale.INSTANCE.getApplicationLocale();
 
         mAlwaysShowTimeStamps = PreferencesManager.alwaysShowTimeStamps(VectorApp.getInstance());
-        mHideReadReceipts = PreferencesManager.showReadReceipts(VectorApp.getInstance());
+        mShowReadReceipts = PreferencesManager.showReadReceipts(VectorApp.getInstance());
 
         mPadlockDrawable = ThemeUtils.INSTANCE.tintDrawable(mContext,
                 ContextCompat.getDrawable(mContext, R.drawable.e2e_unencrypted), R.attr.vctr_settings_icon_tint_color);
@@ -1173,7 +1173,7 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
         VectorMessagesAdapterHelper.setHeader(convertView, headerMessage(position), position);
 
         // read receipts
-        if (mHideReadReceipts) {
+        if (!mShowReadReceipts) {
             mHelper.hideReadReceipts(convertView);
         } else {
             mHelper.displayReadReceipts(convertView, row, mIsPreviewMode, mLiveRoomMembers);

--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapter.java
@@ -375,7 +375,7 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
         mLocale = VectorLocale.INSTANCE.getApplicationLocale();
 
         mAlwaysShowTimeStamps = PreferencesManager.alwaysShowTimeStamps(VectorApp.getInstance());
-        mHideReadReceipts = PreferencesManager.hideReadReceipts(VectorApp.getInstance());
+        mHideReadReceipts = PreferencesManager.showReadReceipts(VectorApp.getInstance());
 
         mPadlockDrawable = ThemeUtils.INSTANCE.tintDrawable(mContext,
                 ContextCompat.getDrawable(mContext, R.drawable.e2e_unencrypted), R.attr.vctr_settings_icon_tint_color);
@@ -1782,11 +1782,11 @@ public class VectorMessagesAdapter extends AbstractMessagesAdapter {
             RoomMember roomMember = JsonUtils.toRoomMember(event.getContent());
             String membership = roomMember.membership;
 
-            if (PreferencesManager.hideJoinLeaveMessages(mContext)) {
+            if (!PreferencesManager.showJoinLeaveMessages(mContext)) {
                 isSupported = !TextUtils.equals(membership, RoomMember.MEMBERSHIP_LEAVE) && !TextUtils.equals(membership, RoomMember.MEMBERSHIP_JOIN);
             }
 
-            if (isSupported && PreferencesManager.hideAvatarDisplayNameChangeMessages(mContext) && TextUtils.equals(membership, RoomMember.MEMBERSHIP_JOIN)) {
+            if (isSupported && !PreferencesManager.showAvatarDisplayNameChangeMessages(mContext) && TextUtils.equals(membership, RoomMember.MEMBERSHIP_JOIN)) {
                 EventContent eventContent = JsonUtils.toEventContent(event.getContentAsJsonObject());
                 EventContent prevEventContent = event.getPrevContent();
 

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -65,19 +65,15 @@ public class PreferencesManager {
     public static final String SETTINGS_NOTIFICATIONS_TARGET_DIVIDER_PREFERENCE_KEY = "SETTINGS_NOTIFICATIONS_TARGET_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_IGNORED_USERS_PREFERENCE_KEY = "SETTINGS_IGNORED_USERS_PREFERENCE_KEY";
     public static final String SETTINGS_IGNORE_USERS_DIVIDER_PREFERENCE_KEY = "SETTINGS_IGNORE_USERS_DIVIDER_PREFERENCE_KEY";
-    public static final String SETTINGS_DEVICES_LIST_PREFERENCE_KEY = "SETTINGS_DEVICES_LIST_PREFERENCE_KEY";
-    public static final String SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY = "SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY";
-    public static final String SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY";
-    public static final String SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY";
     public static final String SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_LABS_PREFERENCE_KEY = "SETTINGS_LABS_PREFERENCE_KEY";
+    public static final String SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY";
+    public static final String SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY";
+    public static final String SETTINGS_DEVICES_LIST_PREFERENCE_KEY = "SETTINGS_DEVICES_LIST_PREFERENCE_KEY";
+    public static final String SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY = "SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_PREFERENCE_KEY = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_PREFERENCE_KEY";
-    public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY
-            = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY";
-    public static final String SETTINGS_PROFILE_PICTURE_PREFERENCE_KEY = "SETTINGS_PROFILE_PICTURE_PREFERENCE_KEY";
-    public static final String SETTINGS_CONTACTS_PHONEBOOK_COUNTRY_PREFERENCE_KEY = "SETTINGS_CONTACTS_PHONEBOOK_COUNTRY_PREFERENCE_KEY";
-    public static final String SETTINGS_INTERFACE_LANGUAGE_PREFERENCE_KEY = "SETTINGS_INTERFACE_LANGUAGE_PREFERENCE_KEY";
+    public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_INFORMATION_DEVICE_NAME_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_INFORMATION_DEVICE_NAME_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_INFORMATION_DEVICE_ID_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_INFORMATION_DEVICE_ID_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_EXPORT_E2E_ROOM_KEYS_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_EXPORT_E2E_ROOM_KEYS_PREFERENCE_KEY";
@@ -85,19 +81,15 @@ public class PreferencesManager {
     public static final String SETTINGS_ENCRYPTION_NEVER_SENT_TO_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_NEVER_SENT_TO_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_INFORMATION_DEVICE_KEY_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_INFORMATION_DEVICE_KEY_PREFERENCE_KEY";
 
+    // user
     public static final String SETTINGS_DISPLAY_NAME_PREFERENCE_KEY = "SETTINGS_DISPLAY_NAME_PREFERENCE_KEY";
-    public static final String SETTINGS_NOTIFICATIONS_KEY = "SETTINGS_NOTIFICATIONS_KEY";
-    public static final String SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY = "SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY";
-    public static final String SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY = "SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY";
-    public static final String SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY = "SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY";
-    public static final String SETTINGS_CONTAINING_MY_DISPLAY_NAME_PREFERENCE_KEY = "SETTINGS_CONTAINING_MY_DISPLAY_NAME_PREFERENCE_KEY_2";
-    public static final String SETTINGS_CONTAINING_MY_USER_NAME_PREFERENCE_KEY = "SETTINGS_CONTAINING_MY_USER_NAME_PREFERENCE_KEY_2";
-    public static final String SETTINGS_MESSAGES_IN_ONE_TO_ONE_PREFERENCE_KEY = "SETTINGS_MESSAGES_IN_ONE_TO_ONE_PREFERENCE_KEY_2";
-    public static final String SETTINGS_MESSAGES_IN_GROUP_CHAT_PREFERENCE_KEY = "SETTINGS_MESSAGES_IN_GROUP_CHAT_PREFERENCE_KEY_2";
-    public static final String SETTINGS_INVITED_TO_ROOM_PREFERENCE_KEY = "SETTINGS_INVITED_TO_ROOM_PREFERENCE_KEY_2";
-    public static final String SETTINGS_CALL_INVITATIONS_PREFERENCE_KEY = "SETTINGS_CALL_INVITATIONS_PREFERENCE_KEY_2";
+    public static final String SETTINGS_PROFILE_PICTURE_PREFERENCE_KEY = "SETTINGS_PROFILE_PICTURE_PREFERENCE_KEY";
+
+    // contacts
+    public static final String SETTINGS_CONTACTS_PHONEBOOK_COUNTRY_PREFERENCE_KEY = "SETTINGS_CONTACTS_PHONEBOOK_COUNTRY_PREFERENCE_KEY";
 
     // interface
+    public static final String SETTINGS_INTERFACE_LANGUAGE_PREFERENCE_KEY = "SETTINGS_INTERFACE_LANGUAGE_PREFERENCE_KEY";
     public static final String SETTINGS_INTERFACE_TEXT_SIZE_KEY = "SETTINGS_INTERFACE_TEXT_SIZE_KEY";
     public static final String SETTINGS_SHOW_URL_PREVIEW_KEY = "SETTINGS_SHOW_URL_PREVIEW_KEY";
     private static final String SETTINGS_SEND_TYPING_NOTIF_KEY = "SETTINGS_SEND_TYPING_NOTIF_KEY";
@@ -118,8 +110,18 @@ public class PreferencesManager {
     public static final String SETTINGS_GROUPS_FLAIR_KEY = "SETTINGS_GROUPS_FLAIR_KEY";
 
     // notifications
-    private static final String SETTINGS_NOTIFICATION_RINGTONE_PREFERENCE_KEY = "SETTINGS_NOTIFICATION_RINGTONE_PREFERENCE_KEY";
+    public static final String SETTINGS_NOTIFICATIONS_KEY = "SETTINGS_NOTIFICATIONS_KEY";
+    public static final String SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY = "SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY";
+    public static final String SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY = "SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY";
+    public static final String SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY = "SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY";
+    public static final String SETTINGS_NOTIFICATION_RINGTONE_PREFERENCE_KEY = "SETTINGS_NOTIFICATION_RINGTONE_PREFERENCE_KEY";
     public static final String SETTINGS_NOTIFICATION_RINGTONE_SELECTION_PREFERENCE_KEY = "SETTINGS_NOTIFICATION_RINGTONE_SELECTION_PREFERENCE_KEY";
+    public static final String SETTINGS_CONTAINING_MY_DISPLAY_NAME_PREFERENCE_KEY = "SETTINGS_CONTAINING_MY_DISPLAY_NAME_PREFERENCE_KEY_2";
+    public static final String SETTINGS_CONTAINING_MY_USER_NAME_PREFERENCE_KEY = "SETTINGS_CONTAINING_MY_USER_NAME_PREFERENCE_KEY_2";
+    public static final String SETTINGS_MESSAGES_IN_ONE_TO_ONE_PREFERENCE_KEY = "SETTINGS_MESSAGES_IN_ONE_TO_ONE_PREFERENCE_KEY_2";
+    public static final String SETTINGS_MESSAGES_IN_GROUP_CHAT_PREFERENCE_KEY = "SETTINGS_MESSAGES_IN_GROUP_CHAT_PREFERENCE_KEY_2";
+    public static final String SETTINGS_INVITED_TO_ROOM_PREFERENCE_KEY = "SETTINGS_INVITED_TO_ROOM_PREFERENCE_KEY_2";
+    public static final String SETTINGS_CALL_INVITATIONS_PREFERENCE_KEY = "SETTINGS_CALL_INVITATIONS_PREFERENCE_KEY_2";
 
     // background sync
     public static final String SETTINGS_START_ON_BOOT_PREFERENCE_KEY = "SETTINGS_START_ON_BOOT_PREFERENCE_KEY";
@@ -635,7 +637,7 @@ public class PreferencesManager {
      * @return true if the markdown is enabled
      */
     public static boolean isMarkdownEnabled(Context context) {
-        return !PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SEND_MARKDOWN_KEY, true);
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SEND_MARKDOWN_KEY, true);
     }
 
     /**
@@ -652,30 +654,30 @@ public class PreferencesManager {
     }
 
     /**
-     * Tells if the read receipts must be hidden
+     * Tells if the read receipts should be shown
      *
      * @param context the context
-     * @return true if the read receipts must be hidden
+     * @return true if the read receipts should be shown
      */
     public static boolean showReadReceipts(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SHOW_READ_RECEIPTS_KEY, true);
     }
 
     /**
-     * Tells if the message timestamps must be always shown.
+     * Tells if the message timestamps must be always shown
      *
      * @param context the context
-     * @return true if the message timestamps must be always shown.
+     * @return true if the message timestamps must be always shown
      */
     public static boolean alwaysShowTimeStamps(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY, false);
     }
 
     /**
-     * Tells if the typing notifications must NOT be sent
+     * Tells if the typing notifications should be sent
      *
      * @param context the context
-     * @return true to do NOT send the typing notifs
+     * @return true to send the typing notifs
      */
     public static boolean sendTypingNotifs(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SEND_TYPING_NOTIF_KEY, true);

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -59,8 +59,6 @@ public class PreferencesManager {
     public static final String SETTINGS_COPYRIGHT_PREFERENCE_KEY = "SETTINGS_COPYRIGHT_PREFERENCE_KEY";
     public static final String SETTINGS_CLEAR_CACHE_PREFERENCE_KEY = "SETTINGS_CLEAR_CACHE_PREFERENCE_KEY";
     public static final String SETTINGS_CLEAR_MEDIA_CACHE_PREFERENCE_KEY = "SETTINGS_CLEAR_MEDIA_CACHE_PREFERENCE_KEY";
-    public static final String SETTINGS_ENABLE_BACKGROUND_SYNC_PREFERENCE_KEY = "SETTINGS_ENABLE_BACKGROUND_SYNC_PREFERENCE_KEY";
-    public static final String SETTINGS_OTHERS_PREFERENCE_KEY = "SETTINGS_OTHERS_PREFERENCE_KEY";
     public static final String SETTINGS_USER_SETTINGS_PREFERENCE_KEY = "SETTINGS_USER_SETTINGS_PREFERENCE_KEY";
     public static final String SETTINGS_CONTACT_PREFERENCE_KEYS = "SETTINGS_CONTACT_PREFERENCE_KEYS";
     public static final String SETTINGS_NOTIFICATIONS_TARGETS_PREFERENCE_KEY = "SETTINGS_NOTIFICATIONS_TARGETS_PREFERENCE_KEY";
@@ -71,17 +69,15 @@ public class PreferencesManager {
     public static final String SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY = "SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY";
     public static final String SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY";
+    public static final String SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY";
+    public static final String SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_LABS_PREFERENCE_KEY = "SETTINGS_LABS_PREFERENCE_KEY";
-    public static final String SETTINGS_SET_SYNC_TIMEOUT_PREFERENCE_KEY = "SETTINGS_SET_SYNC_TIMEOUT_PREFERENCE_KEY";
-    public static final String SETTINGS_SET_SYNC_DELAY_PREFERENCE_KEY = "SETTINGS_SET_SYNC_DELAY_PREFERENCE_KEY";
     public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_PREFERENCE_KEY = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_PREFERENCE_KEY";
     public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY
             = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY";
     public static final String SETTINGS_PROFILE_PICTURE_PREFERENCE_KEY = "SETTINGS_PROFILE_PICTURE_PREFERENCE_KEY";
     public static final String SETTINGS_CONTACTS_PHONEBOOK_COUNTRY_PREFERENCE_KEY = "SETTINGS_CONTACTS_PHONEBOOK_COUNTRY_PREFERENCE_KEY";
     public static final String SETTINGS_INTERFACE_LANGUAGE_PREFERENCE_KEY = "SETTINGS_INTERFACE_LANGUAGE_PREFERENCE_KEY";
-    public static final String SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY";
-    public static final String SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_INFORMATION_DEVICE_NAME_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_INFORMATION_DEVICE_NAME_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_INFORMATION_DEVICE_ID_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_INFORMATION_DEVICE_ID_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_EXPORT_E2E_ROOM_KEYS_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_EXPORT_E2E_ROOM_KEYS_PREFERENCE_KEY";
@@ -101,54 +97,55 @@ public class PreferencesManager {
     public static final String SETTINGS_INVITED_TO_ROOM_PREFERENCE_KEY = "SETTINGS_INVITED_TO_ROOM_PREFERENCE_KEY_2";
     public static final String SETTINGS_CALL_INVITATIONS_PREFERENCE_KEY = "SETTINGS_CALL_INVITATIONS_PREFERENCE_KEY_2";
 
-    private static final String SETTINGS_HIDE_READ_RECEIPTS_KEY = "SETTINGS_HIDE_READ_RECEIPTS_KEY";
+    // interface
+    public static final String SETTINGS_INTERFACE_TEXT_SIZE_KEY = "SETTINGS_INTERFACE_TEXT_SIZE_KEY";
+    public static final String SETTINGS_SHOW_URL_PREVIEW_KEY = "SETTINGS_SHOW_URL_PREVIEW_KEY";
+    private static final String SETTINGS_SEND_TYPING_NOTIF_KEY = "SETTINGS_SEND_TYPING_NOTIF_KEY";
+    private static final String SETTINGS_SEND_MARKDOWN_KEY = "SETTINGS_SEND_MARKDOWN_KEY";
     private static final String SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY = "SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY";
     private static final String SETTINGS_12_24_TIMESTAMPS_KEY = "SETTINGS_12_24_TIMESTAMPS_KEY";
-    private static final String SETTINGS_DISABLE_MARKDOWN_KEY = "SETTINGS_DISABLE_MARKDOWN_KEY";
-    private static final String SETTINGS_DONT_SEND_TYPING_NOTIF_KEY = "SETTINGS_DONT_SEND_TYPING_NOTIF_KEY";
-    private static final String SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY = "SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY";
-    private static final String SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY = "SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY";
+    private static final String SETTINGS_SHOW_READ_RECEIPTS_KEY = "SETTINGS_SHOW_READ_RECEIPTS_KEY";
+    private static final String SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY = "SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY";
+    private static final String SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY = "SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY";
+    private static final String SETTINGS_VIBRATE_ON_MENTION_KEY = "SETTINGS_VIBRATE_ON_MENTION_KEY";
+    private static final String SETTINGS_PREVIEW_MEDIA_BEFORE_SENDING_KEY = "SETTINGS_PREVIEW_MEDIA_BEFORE_SENDING_KEY";
 
-    public static final String SETTINGS_MEDIA_SAVING_PERIOD_KEY = "SETTINGS_MEDIA_SAVING_PERIOD_KEY";
-    private static final String SETTINGS_MEDIA_SAVING_PERIOD_SELECTED_KEY = "SETTINGS_MEDIA_SAVING_PERIOD_SELECTED_KEY";
-
+    // home
     private static final String SETTINGS_PIN_UNREAD_MESSAGES_PREFERENCE_KEY = "SETTINGS_PIN_UNREAD_MESSAGES_PREFERENCE_KEY";
     private static final String SETTINGS_PIN_MISSED_NOTIFICATIONS_PREFERENCE_KEY = "SETTINGS_PIN_MISSED_NOTIFICATIONS_PREFERENCE_KEY";
 
-    public static final String SETTINGS_LAZY_LOADING_PREFERENCE_KEY = "SETTINGS_LAZY_LOADING_PREFERENCE_KEY";
-    public static final String SETTINGS_USER_REFUSED_LAZY_LOADING_PREFERENCE_KEY = "SETTINGS_USER_REFUSED_LAZY_LOADING_PREFERENCE_KEY";
-    public static final String SETTINGS_DATA_SAVE_MODE_PREFERENCE_KEY = "SETTINGS_DATA_SAVE_MODE_PREFERENCE_KEY";
-    public static final String SETTINGS_START_ON_BOOT_PREFERENCE_KEY = "SETTINGS_START_ON_BOOT_PREFERENCE_KEY";
-    public static final String SETTINGS_INTERFACE_TEXT_SIZE_KEY = "SETTINGS_INTERFACE_TEXT_SIZE_KEY";
+    // flair
+    public static final String SETTINGS_GROUPS_FLAIR_KEY = "SETTINGS_GROUPS_FLAIR_KEY";
 
-    private static final String SETTINGS_USE_JITSI_CONF_PREFERENCE_KEY = "SETTINGS_USE_JITSI_CONF_PREFERENCE_KEY";
-
+    // notifications
     private static final String SETTINGS_NOTIFICATION_RINGTONE_PREFERENCE_KEY = "SETTINGS_NOTIFICATION_RINGTONE_PREFERENCE_KEY";
     public static final String SETTINGS_NOTIFICATION_RINGTONE_SELECTION_PREFERENCE_KEY = "SETTINGS_NOTIFICATION_RINGTONE_SELECTION_PREFERENCE_KEY";
 
-    public static final String SETTINGS_GROUPS_FLAIR_KEY = "SETTINGS_GROUPS_FLAIR_KEY";
+    // background sync
+    public static final String SETTINGS_START_ON_BOOT_PREFERENCE_KEY = "SETTINGS_START_ON_BOOT_PREFERENCE_KEY";
+    public static final String SETTINGS_ENABLE_BACKGROUND_SYNC_PREFERENCE_KEY = "SETTINGS_ENABLE_BACKGROUND_SYNC_PREFERENCE_KEY";
+    public static final String SETTINGS_SET_SYNC_TIMEOUT_PREFERENCE_KEY = "SETTINGS_SET_SYNC_TIMEOUT_PREFERENCE_KEY";
+    public static final String SETTINGS_SET_SYNC_DELAY_PREFERENCE_KEY = "SETTINGS_SET_SYNC_DELAY_PREFERENCE_KEY";
 
+    // labs
+    public static final String SETTINGS_LAZY_LOADING_PREFERENCE_KEY = "SETTINGS_LAZY_LOADING_PREFERENCE_KEY";
+    public static final String SETTINGS_USER_REFUSED_LAZY_LOADING_PREFERENCE_KEY = "SETTINGS_USER_REFUSED_LAZY_LOADING_PREFERENCE_KEY";
+    public static final String SETTINGS_DATA_SAVE_MODE_PREFERENCE_KEY = "SETTINGS_DATA_SAVE_MODE_PREFERENCE_KEY";
+    private static final String SETTINGS_USE_JITSI_CONF_PREFERENCE_KEY = "SETTINGS_USE_JITSI_CONF_PREFERENCE_KEY";
     private static final String SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY = "SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY";
-
     private static final String SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY = "SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY";
 
-    public static final String SETTINGS_SHOW_URL_PREVIEW_KEY = "SETTINGS_SHOW_URL_PREVIEW_KEY";
-
-    private static final String SETTINGS_VIBRATE_ON_MENTION_KEY = "SETTINGS_VIBRATE_ON_MENTION_KEY";
-
-    // Analytics keys (Piwik, Matomo, etc.)
+    // analytics
     public static final String SETTINGS_USE_ANALYTICS_KEY = "SETTINGS_USE_ANALYTICS_KEY";
-
-    private static final String SETTINGS_PREVIEW_MEDIA_BEFORE_SENDING_KEY = "SETTINGS_PREVIEW_MEDIA_BEFORE_SENDING_KEY";
-
     public static final String SETTINGS_USE_RAGE_SHAKE_KEY = "SETTINGS_USE_RAGE_SHAKE_KEY";
 
-    private static final String SETTINGS_DISPLAY_ALL_EVENTS_KEY = "SETTINGS_DISPLAY_ALL_EVENTS_KEY";
-
+    // other
+    public static final String SETTINGS_MEDIA_SAVING_PERIOD_KEY = "SETTINGS_MEDIA_SAVING_PERIOD_KEY";
+    private static final String SETTINGS_MEDIA_SAVING_PERIOD_SELECTED_KEY = "SETTINGS_MEDIA_SAVING_PERIOD_SELECTED_KEY";
     private static final String DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY = "DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY";
     private static final String DID_ASK_TO_USE_ANALYTICS_TRACKING_KEY = "DID_ASK_TO_USE_ANALYTICS_TRACKING_KEY";
-
     public static final String SETTINGS_DEACTIVATE_ACCOUNT_KEY = "SETTINGS_DEACTIVATE_ACCOUNT_KEY";
+    private static final String SETTINGS_DISPLAY_ALL_EVENTS_KEY = "SETTINGS_DISPLAY_ALL_EVENTS_KEY";
 
     private static final int MEDIA_SAVING_3_DAYS = 0;
     private static final int MEDIA_SAVING_1_WEEK = 1;
@@ -157,12 +154,13 @@ public class PreferencesManager {
 
     // some preferences keys must be kept after a logout
     private static final List<String> mKeysToKeepAfterLogout = Arrays.asList(
-            SETTINGS_HIDE_READ_RECEIPTS_KEY,
+            SETTINGS_SEND_TYPING_NOTIF_KEY,
+            SETTINGS_SEND_MARKDOWN_KEY,
             SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY,
             SETTINGS_12_24_TIMESTAMPS_KEY,
-            SETTINGS_DONT_SEND_TYPING_NOTIF_KEY,
-            SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY,
-            SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY,
+            SETTINGS_SHOW_READ_RECEIPTS_KEY,
+            SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY,
+            SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY,
             SETTINGS_MEDIA_SAVING_PERIOD_KEY,
             SETTINGS_MEDIA_SAVING_PERIOD_SELECTED_KEY,
             SETTINGS_PREVIEW_MEDIA_BEFORE_SENDING_KEY,
@@ -254,23 +252,23 @@ public class PreferencesManager {
     }
 
     /**
-     * Tells if the join / leave membership events must be hidden in the messages list.
+     * Tells if the join and leave membership events should be shown in the messages list.
      *
      * @param context the context
-     * @return true if the join / leave membership events must be hidden in the messages list
+     * @return true if the join and leave membership events should be shown in the messages list
      */
-    public static boolean hideJoinLeaveMessages(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY, false);
+    public static boolean showJoinLeaveMessages(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY, true);
     }
 
     /**
-     * Tells if the avatar / display name events must be hidden in the messages list.
+     * Tells if the avatar and display name events should be shown in the messages list.
      *
      * @param context the context
-     * @return true true if the avatar / display name events must be hidden in the messages list.
+     * @return true true if the avatar and display name events should be shown in the messages list.
      */
-    public static boolean hideAvatarDisplayNameChangeMessages(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY, false);
+    public static boolean showAvatarDisplayNameChangeMessages(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY, true);
     }
 
     /**
@@ -589,8 +587,43 @@ public class PreferencesManager {
 
         if (preferences.contains("MARKDOWN_PREFERENCE_KEY")) {
             preferences.edit()
-                    .putBoolean(SETTINGS_DISABLE_MARKDOWN_KEY, !preferences.getBoolean("MARKDOWN_PREFERENCE_KEY", false))
+                    .putBoolean(SETTINGS_SEND_MARKDOWN_KEY, preferences.getBoolean("MARKDOWN_PREFERENCE_KEY", true))
                     .remove("MARKDOWN_PREFERENCE_KEY")
+                    .apply();
+        }
+
+        if (preferences.contains("SETTINGS_DONT_SEND_TYPING_NOTIF_KEY")) {
+            preferences.edit()
+                    .putBoolean(SETTINGS_SEND_TYPING_NOTIF_KEY, !preferences.getBoolean("SETTINGS_DONT_SEND_TYPING_NOTIF_KEY", true))
+                    .remove("SETTINGS_DONT_SEND_TYPING_NOTIF_KEY")
+                    .apply();
+        }
+
+        if (preferences.contains("SETTINGS_DISABLE_MARKDOWN_KEY")) {
+            preferences.edit()
+                    .putBoolean(SETTINGS_SEND_MARKDOWN_KEY, !preferences.getBoolean("SETTINGS_DISABLE_MARKDOWN_KEY", true))
+                    .remove("SETTINGS_DISABLE_MARKDOWN_KEY")
+                    .apply();
+        }
+
+        if (preferences.contains("SETTINGS_HIDE_READ_RECEIPTS")) {
+            preferences.edit()
+                    .putBoolean(SETTINGS_SHOW_READ_RECEIPTS_KEY, !preferences.getBoolean("SETTINGS_HIDE_READ_RECEIPTS", true))
+                    .remove("SETTINGS_HIDE_READ_RECEIPTS")
+                    .apply();
+        }
+
+        if (preferences.contains("SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY")) {
+            preferences.edit()
+                    .putBoolean(SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY, !preferences.getBoolean("SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY", true))
+                    .remove("SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY")
+                    .apply();
+        }
+
+        if (preferences.contains("SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES")) {
+            preferences.edit()
+                    .putBoolean(SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY, !preferences.getBoolean("SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES", true))
+                    .remove("SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES")
                     .apply();
         }
     }
@@ -602,7 +635,7 @@ public class PreferencesManager {
      * @return true if the markdown is enabled
      */
     public static boolean isMarkdownEnabled(Context context) {
-        return !PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_DISABLE_MARKDOWN_KEY, false);
+        return !PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SEND_MARKDOWN_KEY, true);
     }
 
     /**
@@ -614,7 +647,7 @@ public class PreferencesManager {
     public static void setMarkdownEnabled(Context context, boolean isEnabled) {
         PreferenceManager.getDefaultSharedPreferences(context)
                 .edit()
-                .putBoolean(SETTINGS_DISABLE_MARKDOWN_KEY, !isEnabled)
+                .putBoolean(SETTINGS_SEND_MARKDOWN_KEY, !isEnabled)
                 .apply();
     }
 
@@ -624,8 +657,8 @@ public class PreferencesManager {
      * @param context the context
      * @return true if the read receipts must be hidden
      */
-    public static boolean hideReadReceipts(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_HIDE_READ_RECEIPTS_KEY, false);
+    public static boolean showReadReceipts(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SHOW_READ_RECEIPTS_KEY, true);
     }
 
     /**
@@ -644,8 +677,8 @@ public class PreferencesManager {
      * @param context the context
      * @return true to do NOT send the typing notifs
      */
-    public static boolean dontSendTypingNotifs(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_DONT_SEND_TYPING_NOTIF_KEY, false);
+    public static boolean sendTypingNotifs(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SEND_TYPING_NOTIF_KEY, true);
     }
 
     /**

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -73,7 +73,8 @@ public class PreferencesManager {
     public static final String SETTINGS_DEVICES_LIST_PREFERENCE_KEY = "SETTINGS_DEVICES_LIST_PREFERENCE_KEY";
     public static final String SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY = "SETTINGS_DEVICES_DIVIDER_PREFERENCE_KEY";
     public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_PREFERENCE_KEY = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_PREFERENCE_KEY";
-    public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY";
+    public static final String SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY
+            = "SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_INFORMATION_DEVICE_NAME_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_INFORMATION_DEVICE_NAME_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_INFORMATION_DEVICE_ID_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_INFORMATION_DEVICE_ID_PREFERENCE_KEY";
     public static final String SETTINGS_ENCRYPTION_EXPORT_E2E_ROOM_KEYS_PREFERENCE_KEY = "SETTINGS_ENCRYPTION_EXPORT_E2E_ROOM_KEYS_PREFERENCE_KEY";
@@ -93,7 +94,7 @@ public class PreferencesManager {
     public static final String SETTINGS_INTERFACE_TEXT_SIZE_KEY = "SETTINGS_INTERFACE_TEXT_SIZE_KEY";
     public static final String SETTINGS_SHOW_URL_PREVIEW_KEY = "SETTINGS_SHOW_URL_PREVIEW_KEY";
     private static final String SETTINGS_SEND_TYPING_NOTIF_KEY = "SETTINGS_SEND_TYPING_NOTIF_KEY";
-    private static final String SETTINGS_SEND_MARKDOWN_KEY = "SETTINGS_SEND_MARKDOWN_KEY";
+    private static final String SETTINGS_ENABLE_MARKDOWN_KEY = "SETTINGS_ENABLE_MARKDOWN_KEY";
     private static final String SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY = "SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY";
     private static final String SETTINGS_12_24_TIMESTAMPS_KEY = "SETTINGS_12_24_TIMESTAMPS_KEY";
     private static final String SETTINGS_SHOW_READ_RECEIPTS_KEY = "SETTINGS_SHOW_READ_RECEIPTS_KEY";
@@ -157,7 +158,6 @@ public class PreferencesManager {
     // some preferences keys must be kept after a logout
     private static final List<String> mKeysToKeepAfterLogout = Arrays.asList(
             SETTINGS_SEND_TYPING_NOTIF_KEY,
-            SETTINGS_SEND_MARKDOWN_KEY,
             SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY,
             SETTINGS_12_24_TIMESTAMPS_KEY,
             SETTINGS_SHOW_READ_RECEIPTS_KEY,
@@ -589,7 +589,7 @@ public class PreferencesManager {
 
         if (preferences.contains("MARKDOWN_PREFERENCE_KEY")) {
             preferences.edit()
-                    .putBoolean(SETTINGS_SEND_MARKDOWN_KEY, preferences.getBoolean("MARKDOWN_PREFERENCE_KEY", true))
+                    .putBoolean(SETTINGS_ENABLE_MARKDOWN_KEY, preferences.getBoolean("MARKDOWN_PREFERENCE_KEY", true))
                     .remove("MARKDOWN_PREFERENCE_KEY")
                     .apply();
         }
@@ -603,7 +603,7 @@ public class PreferencesManager {
 
         if (preferences.contains("SETTINGS_DISABLE_MARKDOWN_KEY")) {
             preferences.edit()
-                    .putBoolean(SETTINGS_SEND_MARKDOWN_KEY, !preferences.getBoolean("SETTINGS_DISABLE_MARKDOWN_KEY", true))
+                    .putBoolean(SETTINGS_ENABLE_MARKDOWN_KEY, !preferences.getBoolean("SETTINGS_DISABLE_MARKDOWN_KEY", true))
                     .remove("SETTINGS_DISABLE_MARKDOWN_KEY")
                     .apply();
         }
@@ -624,7 +624,8 @@ public class PreferencesManager {
 
         if (preferences.contains("SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES")) {
             preferences.edit()
-                    .putBoolean(SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY, !preferences.getBoolean("SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES", true))
+                    .putBoolean(SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY,
+                            !preferences.getBoolean("SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES", true))
                     .remove("SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES")
                     .apply();
         }
@@ -637,7 +638,7 @@ public class PreferencesManager {
      * @return true if the markdown is enabled
      */
     public static boolean isMarkdownEnabled(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_SEND_MARKDOWN_KEY, true);
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SETTINGS_ENABLE_MARKDOWN_KEY, true);
     }
 
     /**
@@ -649,7 +650,7 @@ public class PreferencesManager {
     public static void setMarkdownEnabled(Context context, boolean isEnabled) {
         PreferenceManager.getDefaultSharedPreferences(context)
                 .edit()
-                .putBoolean(SETTINGS_SEND_MARKDOWN_KEY, !isEnabled)
+                .putBoolean(SETTINGS_ENABLE_MARKDOWN_KEY, isEnabled)
                 .apply();
     }
 

--- a/vector/src/main/res/values-ar/strings.xml
+++ b/vector/src/main/res/values-ar/strings.xml
@@ -307,14 +307,9 @@
     <string name="settings_contacts_app_permission">تصاريح المتراسلون</string>
     <string name="settings_contacts_phonebook_country">دولة دفتر العناوين</string>
     <string name="settings_devices_list">الأجهزة</string>
-    <string name="settings_hide_read_receipts">أخفِ إخطارات القراءة</string>
-    <string name="settings_dont_send_typings_notifs">لا تُرسل إخطارات الكتابة</string>
     <string name="settings_always_show_timestamps">اعرض أختام الرسائل الزمنية دائما</string>
     <string name="settings_12_24_timestamps">اعرض الأختام الزمنية بنسق ١٢ ساعة (مثلا ٢:٣٠م)</string>
-    <string name="settings_hide_join_leave_messages">أخفِ رسائل الانضمام/الخروج (الدعوات والطرد والمنع لا يتأثر)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">اعرض تغييرات الصور وأسماء العرض</string>
 
-    <string name="settings_disable_markdown">عطّل تنسيق ”ماركداون“ عند الإرسال</string>
     <string name="settings_data_save_mode">وضع حفظ البيانات</string>
 
     <string name="devices_details_dialog_title">تفاصيل الجهاز</string>

--- a/vector/src/main/res/values-ar/strings.xml
+++ b/vector/src/main/res/values-ar/strings.xml
@@ -284,7 +284,7 @@
     <string name="settings_add_email_address">أضِف بريدا إلكترونيا</string>
     <string name="settings_phone_number">الهاتف</string>
     <string name="settings_add_phone_number">أضِف رقم هاتف</string>
-    <string name="settings_title_app_info_link">معلومات التطبيق</string>
+    <string name="settings_app_info_link_title">معلومات التطبيق</string>
 
     <string name="settings_notification_ringtone">صوت الإخطارات</string>
     <string name="settings_turn_screen_on">شغّل الشاشة لمدة ٣ ثواني</string>
@@ -299,7 +299,7 @@
     <string name="settings_copyright">حقوق النسخ</string>
     <string name="settings_privacy_policy">سياسة الخصوصية</string>
     <string name="settings_clear_cache">امسح الخبيئة</string>
-    <string name="settings_clear_medias_cache">امسح خبيئة الوسائط</string>
+    <string name="settings_clear_media_cache">امسح خبيئة الوسائط</string>
     <string name="settings_user_settings">إعدادات المستخدم</string>
     <string name="settings_notifications">الإخطارات</string>
     <string name="settings_advanced">متقدم</string>
@@ -825,7 +825,7 @@
 
     <string name="room_sliding_menu_term_and_conditions">الأحكام والشروط</string>
     <string name="room_sliding_menu_third_party_notices">إشعارات الأطراف الثالثة</string>
-    <string name="settings_summary_app_info_link">شاشة معلومات التطبيق في النظام</string>
+    <string name="settings_app_info_link_summary">شاشة معلومات التطبيق في النظام</string>
     <string name="settings_call_invitations">دعوات المكالمات</string>
     <string name="settings_start_on_boot">ابدأ عن الإقلاع</string>
     <string name="settings_delete_threepid_confirmation">أمتأكّد من إزالة ⁨%1$s⁩ ⁨%2$s⁩؟</string>

--- a/vector/src/main/res/values-bg/strings.xml
+++ b/vector/src/main/res/values-bg/strings.xml
@@ -459,13 +459,8 @@
     <string name="settings_pin_unread_messages">Закачане на стаи с непрочетени съобщения</string>
     <string name="settings_devices_list">Устройства</string>
     <string name="settings_inline_url_preview">Включване по подразбиране на URL прегледи</string>
-    <string name="settings_hide_read_receipts">Скриване на потвържденията за прочитане на съобщение</string>
-    <string name="settings_dont_send_typings_notifs">Не показвай на другите, че в момента пиша</string>
     <string name="settings_always_show_timestamps">Винаги показвай часа на съобщението</string>
     <string name="settings_12_24_timestamps">Показване на времето в 12-часов формат (напр. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Скриване на съобщения за присъединяване/напускане (не засяга покани/изгонвания/блокирания)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Скриване на информацията за промените на аватара и името</string>
-    <string name="settings_disable_markdown">Изключи markdown при изпращане</string>
     <string name="settings_analytics">Статистика</string>
 
     <string name="devices_details_dialog_title">Информация за устройството</string>

--- a/vector/src/main/res/values-bg/strings.xml
+++ b/vector/src/main/res/values-bg/strings.xml
@@ -307,7 +307,7 @@
     <string name="call_connected">Свързано повикване</string>
     <string name="call_error_user_not_responding">Отсрещната страна не успя да отговори на повикването.</string>
     <string name="call_error_ice_failed">Неуспешна връзка с медийното устройство</string>
-    <string name="settings_clear_medias_cache">Изчисти кеша за медия</string>
+    <string name="settings_clear_media_cache">Изчисти кеша за медия</string>
     <string name="settings_keep_media">Запази медия</string>
 
     <string name="call_error_camera_init_failed">Неуспешно подготвяне на камерата</string>
@@ -762,8 +762,8 @@
     <string name="room_details_people_present_group_name">УЧАСТНИЦИ</string>
 
     <string name="room_sync_in_progress">Синхронизиране…</string>
-    <string name="settings_summary_app_info_link">Екран с информация за системата на приложението</string>
-    <string name="settings_title_app_info_link">Информация за приложението</string>
+    <string name="settings_app_info_link_summary">Екран с информация за системата на приложението</string>
+    <string name="settings_app_info_link_title">Информация за приложението</string>
 
     <string name="settings_notification_ringtone">Звук на известията</string>
     <string name="settings_turn_screen_on">Включи екрана за 3 секунди</string>

--- a/vector/src/main/res/values-bs/strings.xml
+++ b/vector/src/main/res/values-bs/strings.xml
@@ -421,8 +421,8 @@ Da li ste sigurani?</string>
     <string name="settings_add_email_address">Dodaj email adresu</string>
     <string name="settings_phone_number">Telefon</string>
     <string name="settings_add_phone_number">Dodaj broj telefona</string>
-    <string name="settings_summary_app_info_link">Infomacije o aplikacijskom sustavu</string>
-    <string name="settings_title_app_info_link">Informacije o aplikaciji</string>
+    <string name="settings_app_info_link_summary">Infomacije o aplikacijskom sustavu</string>
+    <string name="settings_app_info_link_title">Informacije o aplikaciji</string>
 
     <string name="settings_notification_ringtone">Zvuk notifikacije</string>
     <string name="settings_enable_all_notif">Omogući obavijesti za ovaj račun</string>
@@ -452,7 +452,7 @@ Da li ste sigurani?</string>
     <string name="settings_copyright">Copyright</string>
     <string name="settings_privacy_policy">Privatnost</string>
     <string name="settings_clear_cache">Očisti keš</string>
-    <string name="settings_clear_medias_cache">Očisti medija keš</string>
+    <string name="settings_clear_media_cache">Očisti medija keš</string>
     <string name="settings_keep_media">Dodaj medij</string>
 
     <string name="settings_user_settings">Korisničke postavke</string>

--- a/vector/src/main/res/values-bs/strings.xml
+++ b/vector/src/main/res/values-bs/strings.xml
@@ -469,18 +469,13 @@ Da li ste sigurani?</string>
     <string name="settings_pin_missed_notifications">Prikačite sobe sa propuštenim obavijestima</string>
     <string name="settings_pin_unread_messages">Prikačite sobe sa nepročitanim porukama</string>
     <string name="settings_devices_list">Uređaj</string>
-    <string name="settings_hide_read_receipts">Sakrijte pročitane račune</string>
-    <string name="settings_dont_send_typings_notifs">Nemojte slati obavijesti o tipizaciji</string>
     <string name="settings_always_show_timestamps">Uvijek prikažite vremenske oznake poruka</string>
     <string name="settings_12_24_timestamps">Prikaži vremenske oznake u 12-satnom obliku (npr. 14:30)</string>
-    <string name="settings_hide_join_leave_messages">Sakrij poruke o pridruživanju / napuštanju (pozivnice / izbacivanja / neovlaštne zabrane)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Sakrij avatar i promjene imena</string>
 
     <string name="settings_analytics">Analiza</string>
     <string name="attachment_remaining_time_seconds">%d s</string>
     <string name="attachment_remaining_time_minutes">%1$a %2$i</string>
 
-    <string name="settings_disable_markdown">Onemogućite formatiranje oznaka</string>
     <string name="settings_data_save_mode">Način spremanja podataka</string>
 
     <string name="devices_details_dialog_title">Pojedinosti uređaja</string>

--- a/vector/src/main/res/values-ca/strings.xml
+++ b/vector/src/main/res/values-ca/strings.xml
@@ -508,13 +508,8 @@ Tingueu en compte que aquesta acció reiniciarà l\'aplicació i que pot trigar 
     <string name="settings_pin_unread_messages">Destaca les sales amb missatges sense llegir</string>
     <string name="settings_devices_list">Dispositius</string>
     <string name="settings_inline_url_preview">Habilita les previsualitzacions de les URL per defecte</string>
-    <string name="settings_hide_read_receipts">Amaga les entrades llegides</string>
-    <string name="settings_dont_send_typings_notifs">No enviïs notificacions d\'esciptura</string>
     <string name="settings_always_show_timestamps">Mostra sempre l\'hora dels missatges</string>
     <string name="settings_12_24_timestamps">Mostra l\'hora en el format de 12 hores (per exemple 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Amaga els missatges d\'entrada i sortida de participants</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Amaga les fotos de perfil i els canvis de nom visible</string>
-    <string name="settings_disable_markdown">Desactivar el Markdown quan s\'enviï</string>
     <string name="settings_vibrate_on_mention">Vibra quan et mencionin</string>
 
     <!-- analytics -->

--- a/vector/src/main/res/values-ca/strings.xml
+++ b/vector/src/main/res/values-ca/strings.xml
@@ -459,8 +459,8 @@ Tingueu en compte que aquesta acció reiniciarà l\'aplicació i que pot trigar 
     <string name="settings_add_email_address">Afegeix una adreça de correu electrònic</string>
     <string name="settings_phone_number">Telèfon</string>
     <string name="settings_add_phone_number">Afegeix un número de telèfon</string>
-    <string name="settings_summary_app_info_link">Pantalla d\'informació del sistema de l\'aplicació</string>
-    <string name="settings_title_app_info_link">Informació de l\'aplicació</string>
+    <string name="settings_app_info_link_summary">Pantalla d\'informació del sistema de l\'aplicació</string>
+    <string name="settings_app_info_link_title">Informació de l\'aplicació</string>
 
     <string name="settings_notification_ringtone">So de les notificación</string>
     <string name="settings_enable_all_notif">Habilita les notificacions d\'aquest compte</string>
@@ -490,7 +490,7 @@ Tingueu en compte que aquesta acció reiniciarà l\'aplicació i que pot trigar 
     <string name="settings_copyright">Copyright</string>
     <string name="settings_privacy_policy">Política de privacitat</string>
     <string name="settings_clear_cache">Esborra la memòria cau</string>
-    <string name="settings_clear_medias_cache">Esborra la memòria cau multimèdia</string>
+    <string name="settings_clear_media_cache">Esborra la memòria cau multimèdia</string>
     <string name="settings_keep_media">Manté els elements multimèdia</string>
 
     <string name="settings_user_settings">Configuració de l\'usuari</string>

--- a/vector/src/main/res/values-da/strings.xml
+++ b/vector/src/main/res/values-da/strings.xml
@@ -504,7 +504,7 @@ Er du sikker?</string>
     <string name="settings_copyright">Copyright</string>
     <string name="settings_privacy_policy">Privacy-politik</string>
     <string name="settings_clear_cache">Ryd cache</string>
-    <string name="settings_clear_medias_cache">Ryd mediecache</string>
+    <string name="settings_clear_media_cache">Ryd mediecache</string>
     <string name="settings_keep_media">Beholde mediefiler</string>
 
     <string name="settings_user_settings">Brugerindstillinger</string>

--- a/vector/src/main/res/values-de/strings.xml
+++ b/vector/src/main/res/values-de/strings.xml
@@ -442,8 +442,8 @@ Beachte: Diese Aktion wird die App neu starten und einige Zeit brauchen.</string
     <string name="settings_add_email_address">E-Mail-Adresse hinzufügen</string>
     <string name="settings_phone_number">Telefonnummer</string>
     <string name="settings_add_phone_number">Telefonnummer hinzufügen</string>
-    <string name="settings_summary_app_info_link">App-Info-Anzeige von Android</string>
-    <string name="settings_title_app_info_link">App-Info</string>
+    <string name="settings_app_info_link_summary">App-Info-Anzeige von Android</string>
+    <string name="settings_app_info_link_title">App-Info</string>
 
     <string name="settings_enable_all_notif">Benachrichtigungen für diesen Account aktivieren</string>
     <string name="settings_enable_this_device">Benachrichtigungen für dieses Gerät aktivieren</string>
@@ -700,7 +700,7 @@ Unbekannte Geräte:</string>
     <string name="settings_select_language">Wähle eine Sprache</string>
 
     <string name="settings_start_on_boot">Starte beim Systemstart</string>
-    <string name="settings_clear_medias_cache">Medien-Cache leeren</string>
+    <string name="settings_clear_media_cache">Medien-Cache leeren</string>
     <string name="settings_keep_media">Medien behalten</string>
 
     <string name="settings_always_show_timestamps">Nachrichten-Zeitstempel immer anzeigen</string>

--- a/vector/src/main/res/values-de/strings.xml
+++ b/vector/src/main/res/values-de/strings.xml
@@ -703,10 +703,7 @@ Unbekannte Geräte:</string>
     <string name="settings_clear_medias_cache">Medien-Cache leeren</string>
     <string name="settings_keep_media">Medien behalten</string>
 
-    <string name="settings_hide_read_receipts">Lesebestätigungen verbergen</string>
-    <string name="settings_dont_send_typings_notifs">Sende nicht, dass ich tippe</string>
     <string name="settings_always_show_timestamps">Nachrichten-Zeitstempel immer anzeigen</string>
-    <string name="settings_disable_markdown">Markdown-Formatierung beim Senden deaktivieren</string>
 
     <string name="media_saving_period_3_days">3 Tage</string>
     <string name="media_saving_period_1_week">1 Woche</string>
@@ -730,8 +727,6 @@ Unbekannte Geräte:</string>
 <string name="settings_theme">Thema</string>
 
     <string name="settings_12_24_timestamps">Zeitstempel im 12-Stunden-Format anzeigen (z. B. 2:30 p. m.)</string>
-    <string name="settings_hide_join_leave_messages">Betreten-/Verlassen-Meldungen verbergen (gilt nicht für Einladungen/Kicks/Bans)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Profilbild- und Anzeigenamen-Änderungen verbergen</string>
 
     <string name="widget_no_power_to_manage">Für das Verwalten von Widgets in diesem Raum ist eine Berechtigung erforderlich</string>
     <string name="widget_creation_failure">Widget konnte nicht erstellt werden</string>

--- a/vector/src/main/res/values-es-rMX/strings.xml
+++ b/vector/src/main/res/values-es-rMX/strings.xml
@@ -434,8 +434,8 @@ Mensajes cifrados no serán visibles en cuentas que no implementan el cifrado.</
     <string name="settings_add_email_address">Añadir correo electrónico</string>
     <string name="settings_phone_number">Número Telefónico</string>
     <string name="settings_add_phone_number">Añadir número telefónico</string>
-    <string name="settings_summary_app_info_link">Página de la información del sistema de la aplicación</string>
-    <string name="settings_title_app_info_link">Información de la Aplicación</string>
+    <string name="settings_app_info_link_summary">Página de la información del sistema de la aplicación</string>
+    <string name="settings_app_info_link_title">Información de la Aplicación</string>
 
     <string name="settings_enable_all_notif">Encender notificaciones para esta cuenta</string>
     <string name="settings_enable_this_device">Encender notificaciones para este dispositivo</string>

--- a/vector/src/main/res/values-es/strings.xml
+++ b/vector/src/main/res/values-es/strings.xml
@@ -718,10 +718,7 @@ Dispositivos desconocidos:</string>
     <string name="settings_clear_medias_cache">Borrar caché de medios</string>
     <string name="settings_keep_media">Guardar medios</string>
 
-    <string name="settings_hide_read_receipts">Ocultar recibos de lectura</string>
-    <string name="settings_dont_send_typings_notifs">No enviar notificaciones de estar escribiendo</string>
     <string name="settings_always_show_timestamps">Siempre mostrar las marcas temporales de mensajes</string>
-    <string name="settings_disable_markdown">Deshabilitar el formato markdown cuando se envía</string>
 
     <string name="media_saving_period_3_days">3 días</string>
     <string name="media_saving_period_1_week">1 semana</string>
@@ -765,8 +762,6 @@ Dispositivos desconocidos:</string>
     <string name="settings_containing_my_display_name">Mensajes que contienen mi nombre público</string>
     <string name="settings_containing_my_user_name">Mensajes que contienen mi nombre de usuario</string>
     <string name="settings_12_24_timestamps">Mostrar marcas temporales en formato de 12 horas (ej. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Ocultar mensajes de unirse/salir (no afecta a invitaciones/expulsiones/vetos)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Ocultar cambios de avatar y nombre público</string>
 
     <string name="settings_analytics">Análisis de Estadísticas</string>
 

--- a/vector/src/main/res/values-es/strings.xml
+++ b/vector/src/main/res/values-es/strings.xml
@@ -456,8 +456,8 @@ Ten en cuenta que esta acción reiniciará la aplicación y puede tardar algo de
     <string name="settings_add_email_address">Añadir dirección de correo electrónico</string>
     <string name="settings_phone_number">Teléfono</string>
     <string name="settings_add_phone_number">Añadir número telefónico</string>
-    <string name="settings_summary_app_info_link">Pantalla de información del sistema de la aplicación</string>
-    <string name="settings_title_app_info_link">Información de la aplicación</string>
+    <string name="settings_app_info_link_summary">Pantalla de información del sistema de la aplicación</string>
+    <string name="settings_app_info_link_title">Información de la aplicación</string>
 
     <string name="settings_enable_all_notif">Habilitar notificaciones para esta cuenta</string>
     <string name="settings_enable_this_device">Habilitar notificaciones para este dispositivo</string>
@@ -715,7 +715,7 @@ Dispositivos desconocidos:</string>
     <string name="settings_select_language">Elige un idioma</string>
 
     <string name="settings_start_on_boot">Iniciar en el arranque</string>
-    <string name="settings_clear_medias_cache">Borrar caché de medios</string>
+    <string name="settings_clear_media_cache">Borrar caché de medios</string>
     <string name="settings_keep_media">Guardar medios</string>
 
     <string name="settings_always_show_timestamps">Siempre mostrar las marcas temporales de mensajes</string>

--- a/vector/src/main/res/values-eu/strings.xml
+++ b/vector/src/main/res/values-eu/strings.xml
@@ -460,8 +460,6 @@ Kontuan izan ekintza honek aplikazioa berrabiaraziko duela eta denbora bat behar
     <string name="settings_pin_missed_notifications">Finkatu ikusi gabeko jakinarazpenak dituzten gelak</string>
     <string name="settings_pin_unread_messages">Finkatu irakurri gabeko mezuak dituzten gelak</string>
     <string name="settings_devices_list">Gailuak</string>
-    <string name="settings_hide_read_receipts">Ezkutatu irakurragiriak</string>
-    <string name="settings_dont_send_typings_notifs">Ez bidali idatzi bitarteko jakinarazpenak</string>
     <string name="settings_always_show_timestamps">Erakutsi beti mezuen denbora-zigilua</string>
     <string name="devices_details_dialog_title">Gailuaren xehetasunak</string>
     <string name="devices_details_id_title">ID</string>
@@ -511,7 +509,6 @@ Kontuan izan ekintza honek aplikazioa berrabiaraziko duela eta denbora bat behar
 
     <string name="room_sliding_menu_third_party_notices">Hirugarrengoen adierazpenak</string>
     <string name="settings_third_party_notices">Hirugarrengoen adierazpenak</string>
-    <string name="settings_disable_markdown">Desgaitu markdown formatua bidaltzean</string>
 
     <string name="settings_phone_number_label">Telefono zenbakia</string>
     <string name="settings_phone_number_error">Telefono zenbaki baliogabea hautatutako herrialdean</string>
@@ -695,8 +692,6 @@ Zifratutako mezuak ez dira zifratzea oraindik ezarrita ez duten beste gailuetan 
 
     <string name="settings_notification_ringtone">Jakinarazpen-soinua</string>
     <string name="settings_12_24_timestamps">Erakutsi denbora-zigiluak 12 ordutako formatuan (adib 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Ezkutatu elkartu/utzi mezuak (gonbidatu/kanporatu/debekatu mezuei eraginik ez)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Ezkutatu abatarraren eta pantaila-izenen aldaketak</string>
 
     <string name="widget_no_power_to_manage">Baimena behar duzu gela honetako trepetak kudeatzeko</string>
     <string name="widget_creation_failure">Trepetaren sorrerak huts egin du</string>

--- a/vector/src/main/res/values-eu/strings.xml
+++ b/vector/src/main/res/values-eu/strings.xml
@@ -417,8 +417,8 @@ Kontuan izan ekintza honek aplikazioa berrabiaraziko duela eta denbora bat behar
     <string name="settings_add_email_address">Gehitu e-mail helbidea</string>
     <string name="settings_phone_number">Telefonoa</string>
     <string name="settings_add_phone_number">Gehitu telefono zenbakia</string>
-    <string name="settings_summary_app_info_link">Aplikazioaren sistema-informazio pantaila</string>
-    <string name="settings_title_app_info_link">Aplikazioaren informazioa</string>
+    <string name="settings_app_info_link_summary">Aplikazioaren sistema-informazio pantaila</string>
+    <string name="settings_app_info_link_title">Aplikazioaren informazioa</string>
 
     <string name="settings_enable_all_notif">Gaitu jakinarazpenak kontu honetarako</string>
     <string name="settings_enable_this_device">Gaitu jakinarazpenak gailu honetan</string>
@@ -444,7 +444,7 @@ Kontuan izan ekintza honek aplikazioa berrabiaraziko duela eta denbora bat behar
     <string name="settings_copyright">Copyright-a</string>
     <string name="settings_privacy_policy">Pribatutasun politika</string>
     <string name="settings_clear_cache">Garbitu cachea</string>
-    <string name="settings_clear_medias_cache">Garbitu media cachea</string>
+    <string name="settings_clear_media_cache">Garbitu media cachea</string>
     <string name="settings_keep_media">Mantendu media</string>
 
     <string name="settings_user_settings">Erabiltzaile-ezarpenak</string>

--- a/vector/src/main/res/values-fi/strings.xml
+++ b/vector/src/main/res/values-fi/strings.xml
@@ -695,10 +695,7 @@ Voit tehdä sen nyt tai myöhemmin sovelluksen asetuksissa.</string>
     <string name="settings_clear_medias_cache">Tyhjennä mediavälimuisti</string>
     <string name="settings_keep_media">Säilytä media</string>
 
-    <string name="settings_hide_read_receipts">Piilota lukukuittaukset</string>
-    <string name="settings_dont_send_typings_notifs">Älä lähetä kirjoitusilmoituksia</string>
     <string name="settings_always_show_timestamps">Näytä aina aikaleimat</string>
-    <string name="settings_disable_markdown">Poista markdown -muotoilu käytöstä</string>
     <string name="settings_data_save_mode">Datansäästötila</string>
 
     <string name="settings_user_interface">Käyttöliittymä</string>
@@ -743,8 +740,6 @@ Voit tehdä sen nyt tai myöhemmin sovelluksen asetuksissa.</string>
     <string name="settings_containing_my_display_name">Viesti sisältää näyttönimeni</string>
     <string name="settings_containing_my_user_name">Viesti sisältää käyttäjänimeni</string>
     <string name="settings_12_24_timestamps">Näytä aikaleimat 12h muodossa (esim. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Piilota liittymis-/poistumisilmoitukset (ei vaikuta kutsuihin/poistoihin/estoihin)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Piilota kuvan ja näyttönimen muutokset</string>
 
     <string name="settings_analytics">Analytiikka</string>
 

--- a/vector/src/main/res/values-fi/strings.xml
+++ b/vector/src/main/res/values-fi/strings.xml
@@ -446,8 +446,8 @@ Salatut viestit eivät näy sovelluksissa, jotka eivät tue salausta.</string> <
     <string name="settings_add_email_address">Lisää sähköpostiosoite</string>
     <string name="settings_phone_number">Puhelin</string>
     <string name="settings_add_phone_number">Lisää puhelinnumero</string>
-    <string name="settings_summary_app_info_link">Sovelluksen infonäyttö</string>
-    <string name="settings_title_app_info_link">Sovelluksen tiedot</string>
+    <string name="settings_app_info_link_summary">Sovelluksen infonäyttö</string>
+    <string name="settings_app_info_link_title">Sovelluksen tiedot</string>
 
     <string name="settings_enable_all_notif">Ota ilmoitukset käyttöön tällä tilillä</string>
     <string name="settings_enable_this_device">Ota ilmoitukset käyttöön tällä laitteella</string>
@@ -692,7 +692,7 @@ Voit tehdä sen nyt tai myöhemmin sovelluksen asetuksissa.</string>
 <string name="user_directory_header">Käyttäjähakemisto</string>
     <string name="people_search_user_directory">KÄYTTÄJÄHAKEMISTO (%s)</string>
     <string name="settings_start_on_boot">Käynnistä automaattisesti</string>
-    <string name="settings_clear_medias_cache">Tyhjennä mediavälimuisti</string>
+    <string name="settings_clear_media_cache">Tyhjennä mediavälimuisti</string>
     <string name="settings_keep_media">Säilytä media</string>
 
     <string name="settings_always_show_timestamps">Näytä aina aikaleimat</string>

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -668,10 +668,7 @@ Appareils inconnus :</string>
     <string name="settings_clear_medias_cache">Vider le cache des médias</string>
     <string name="settings_keep_media">Conserver les médias</string>
 
-    <string name="settings_hide_read_receipts">Masquer les accusés de lecture</string>
-    <string name="settings_dont_send_typings_notifs">Ne pas envoyer de notification d\'écriture</string>
     <string name="settings_always_show_timestamps">Toujours afficher l\'heure des messages</string>
-    <string name="settings_disable_markdown">Désactiver le formatage Markdown lors de l\'envoi des messages</string>
     <string name="settings_data_save_mode">Mode économie de données</string>
 
     <string name="media_saving_period_3_days">3 jours</string>
@@ -700,8 +697,6 @@ Appareils inconnus :</string>
 
     <string name="settings_notification_ringtone">Son de notification</string>
     <string name="settings_12_24_timestamps">Afficher l\'horodatage au format 12 heures (par ex. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Masquer les messages d\'arrivée/départ (les invitations/exclusions/bannissements ne sont pas concernés)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Masquer les changements d\'avatar et de nom</string>
 
     <string name="widget_no_power_to_manage">Vous avez besoin d\'une permission pour gérer les widgets de ce salon</string>
     <string name="widget_creation_failure">La création du widget a échoué</string>

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -282,8 +282,8 @@ Cliquez sur exporter pour les sauvegarder avant de vous déconnecter.</string>
     <string name="settings_add_email_address">Ajouter une adresse e-mail</string>
     <string name="settings_phone_number">Téléphone</string>
     <string name="settings_add_phone_number">Ajouter un numéro de téléphone</string>
-    <string name="settings_summary_app_info_link">Information sur l\'application</string>
-    <string name="settings_title_app_info_link">Informations sur l\'application</string>
+    <string name="settings_app_info_link_summary">Information sur l\'application</string>
+    <string name="settings_app_info_link_title">Informations sur l\'application</string>
 
     <string name="settings_enable_all_notif">Activer les notifications pour ce compte</string>
     <string name="settings_enable_this_device">Activer les notifications pour cet appareil</string>
@@ -665,7 +665,7 @@ Appareils inconnus :</string>
 
     <string name="people_search_user_directory">RÉPERTOIRE UTILISATEUR (%s)</string>
     <string name="settings_start_on_boot">Lancer au démarrage</string>
-    <string name="settings_clear_medias_cache">Vider le cache des médias</string>
+    <string name="settings_clear_media_cache">Vider le cache des médias</string>
     <string name="settings_keep_media">Conserver les médias</string>
 
     <string name="settings_always_show_timestamps">Toujours afficher l\'heure des messages</string>

--- a/vector/src/main/res/values-gl/strings.xml
+++ b/vector/src/main/res/values-gl/strings.xml
@@ -299,7 +299,7 @@ Pode engadir a dirección de correo na sección de configuración de perfil.</st
     <string name="settings_version">Versión</string>
     <string name="settings_olm_version">versións anteriores</string>
     <string name="settings_clear_cache">Limpar o caché</string>
-    <string name="settings_clear_medias_cache">Limpar o caché de imaxes</string>
+    <string name="settings_clear_media_cache">Limpar o caché de imaxes</string>
     <string name="settings_keep_media">Manter as imaxes</string>
 
     <string name="settings_user_settings">Configuracións dos usuarios</string>

--- a/vector/src/main/res/values-gl/strings.xml
+++ b/vector/src/main/res/values-gl/strings.xml
@@ -309,11 +309,8 @@ Pode engadir a dirección de correo na sección de configuración de perfil.</st
     <string name="settings_cryptography">Criptografía</string>
     <string name="settings_devices_list">Dispositivos</string>
     <string name="settings_inline_url_preview">Activar por defecto as vistas previas en liña de URL</string>
-    <string name="settings_hide_read_receipts">Ocultar avisos de recepción</string>
-    <string name="settings_dont_send_typings_notifs">Non enviar notificacións de escritura</string>
     <string name="settings_always_show_timestamps">Mostrar sempre marcas de tempo</string>
     <string name="settings_12_24_timestamps">"Mostrar marcas  de tempo con formato 12 horas (ex. 2:30pm)"</string>
-    <string name="settings_hide_join_leave_messages">Ocultar mensaxes de unión/saída (convites/expulsións/bloqueos non afectados)</string>
     <string name="settings_deactivate_my_account">Desactivar a miña conta</string>
 
     <string name="settings_analytics">Analytics</string>

--- a/vector/src/main/res/values-hu/strings.xml
+++ b/vector/src/main/res/values-hu/strings.xml
@@ -416,8 +416,8 @@ Vedd figyelembe, hogy az alkalmazás újraindul  ami sok időt vehet igénybe."<
     <string name="settings_add_email_address">E-mail cím hozzáadása</string>
     <string name="settings_phone_number">Telefon</string>
     <string name="settings_add_phone_number">Telefonszám hozzáadása</string>
-    <string name="settings_summary_app_info_link">Alkalmazás infók a rendszerbeállításokban</string>
-    <string name="settings_title_app_info_link">Alkalmazás infó</string>
+    <string name="settings_app_info_link_summary">Alkalmazás infók a rendszerbeállításokban</string>
+    <string name="settings_app_info_link_title">Alkalmazás infó</string>
 
     <string name="settings_enable_all_notif">Értesítések bekapcsolása ehhez a felhasználóhoz</string>
     <string name="settings_enable_this_device">Értesítések bekapcsolása ehhez a készülékhez</string>
@@ -655,7 +655,7 @@ Ismeretlen eszközök:</string>
     <string name="account_phone_number_already_used_error">Ez a telefonszám már használatban van</string>
 
     <string name="settings_start_on_boot">Indítás rendszerinduláskor</string>
-    <string name="settings_clear_medias_cache">Média gyorsítótár törlése</string>
+    <string name="settings_clear_media_cache">Média gyorsítótár törlése</string>
     <string name="settings_keep_media">Média megtartása</string>
 
     <string name="settings_always_show_timestamps">Mindig jelenítse meg az üzenetek időbélyegét</string>

--- a/vector/src/main/res/values-hu/strings.xml
+++ b/vector/src/main/res/values-hu/strings.xml
@@ -658,16 +658,13 @@ Ismeretlen eszközök:</string>
     <string name="settings_clear_medias_cache">Média gyorsítótár törlése</string>
     <string name="settings_keep_media">Média megtartása</string>
 
-    <string name="settings_dont_send_typings_notifs">Ne küldjön írásértesítést</string>
     <string name="settings_always_show_timestamps">Mindig jelenítse meg az üzenetek időbélyegét</string>
-    <string name="settings_disable_markdown">Markdown formázás kikapcsolása üzenet küldésekor</string>
 
     <string name="media_saving_period_3_days">3 nap</string>
     <string name="media_saving_period_1_week">1 hét</string>
     <string name="media_saving_period_1_month">1 hónap</string>
     <string name="media_saving_period_forever">Örökké</string>
 
-    <string name="settings_hide_read_receipts">Tértivevény elrejtése</string>
     <string name="people_search_user_directory">FELHASZNÁLÓ JEGYZÉK (%S)</string>
     <string name="settings_data_save_mode">Adattakarékos mód</string>
 
@@ -692,8 +689,6 @@ Ismeretlen eszközök:</string>
 
     <string name="settings_notification_ringtone">Értesítés hangja</string>
     <string name="settings_12_24_timestamps">Időbélyegek mutatása 12 órás formátumban (pl.: du. 2:30)</string>
-    <string name="settings_hide_join_leave_messages">Belépés/kilépés üzenetek elrejtése (meghívást/kirúgást/kitiltást nem érinti)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Profilkép és -név változásainak elrejtése</string>
 
     <string name="widget_no_power_to_manage">Engedélyre van szükséged a kisalkalmazások ebben a szobában való kezeléséhez</string>
     <string name="widget_creation_failure">Kisalkalmazás létrehozása sikertelen</string>

--- a/vector/src/main/res/values-id/strings.xml
+++ b/vector/src/main/res/values-id/strings.xml
@@ -892,13 +892,8 @@ Peringatan: berkas ini mungkin ikut terhapus jika aplikasi dihapus.</string>
     <string name="settings_pin_unread_messages">Semat ruang yang pesannya belum terbaca</string>
     <string name="settings_devices_list">Perangkat</string>
     <string name="settings_inline_url_preview">Perbolehkan pratinjau URL dalam obrolan</string>
-    <string name="settings_hide_read_receipts">Sembunyi tanda \'telah terbaca\'</string>
-    <string name="settings_dont_send_typings_notifs">Jangan kirim pemberitahuan \'sedang mengetik\'</string>
     <string name="settings_always_show_timestamps">Selalu perlihatkan waktu pesan</string>
     <string name="settings_12_24_timestamps">Perlihatkan waktu pesan dengan format 12 jam (misalnya 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Sembunyikan pesan \'bergabung\'/\'meninggalkan\' (undangan/pengeluaran/pelarangan tidak terpengaruh)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Sembunyikan avatar dan perubahan nama layar</string>
-    <string name="settings_disable_markdown">Nonaktifkan format markdown ketika mengirim</string>
     <string name="settings_vibrate_on_mention">Bergetar ketika disebut</string>
     <string name="settings_preview_media_before_sending">Pratinjau media sebelum dikirim</string>
 

--- a/vector/src/main/res/values-id/strings.xml
+++ b/vector/src/main/res/values-id/strings.xml
@@ -551,8 +551,8 @@ Perhatikan bahwa tindakan ini akan memulai ulang aplikasi dan mungkin cukup mema
     <string name="settings_add_email_address">Tambahkan alamat email</string>
     <string name="settings_phone_number">Telepon</string>
     <string name="settings_add_phone_number">Tambahkan nomor telepon</string>
-    <string name="settings_summary_app_info_link">Layar info sistem aplikasi</string>
-    <string name="settings_title_app_info_link">Info aplikasi</string>
+    <string name="settings_app_info_link_summary">Layar info sistem aplikasi</string>
+    <string name="settings_app_info_link_title">Info aplikasi</string>
 
     <string name="settings_notification_privacy">Kerahasiaan pemberitahuan</string>
     <string name="settings_notification_privacy_warning">Riot.im beroperasi di balik layar untuk menjaga kerahasiaan isi pesan pemberitahuan. Anda dapat mengubah pengaturan untuk mengurangi penggunaan baterai.</string>
@@ -874,7 +874,7 @@ Peringatan: berkas ini mungkin ikut terhapus jika aplikasi dihapus.</string>
     <string name="settings_copyright">Hak Cipta</string>
     <string name="settings_privacy_policy">Kebijakan Pribadi</string>
     <string name="settings_clear_cache">Bersihkan cache</string>
-    <string name="settings_clear_medias_cache">Bersihkan cache media</string>
+    <string name="settings_clear_media_cache">Bersihkan cache media</string>
     <string name="settings_keep_media">Pertahankan media</string>
 
     <string name="settings_user_settings">Pengaturan pengguna</string>

--- a/vector/src/main/res/values-in/strings.xml
+++ b/vector/src/main/res/values-in/strings.xml
@@ -892,13 +892,8 @@ Peringatan: berkas ini mungkin ikut terhapus jika aplikasi dihapus.</string>
     <string name="settings_pin_unread_messages">Semat ruang yang pesannya belum terbaca</string>
     <string name="settings_devices_list">Perangkat</string>
     <string name="settings_inline_url_preview">Perbolehkan pratinjau URL dalam obrolan</string>
-    <string name="settings_hide_read_receipts">Sembunyi tanda \'telah terbaca\'</string>
-    <string name="settings_dont_send_typings_notifs">Jangan kirim pemberitahuan \'sedang mengetik\'</string>
     <string name="settings_always_show_timestamps">Selalu perlihatkan waktu pesan</string>
     <string name="settings_12_24_timestamps">Perlihatkan waktu pesan dengan format 12 jam (misalnya 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Sembunyikan pesan \'bergabung\'/\'meninggalkan\' (undangan/pengeluaran/pelarangan tidak terpengaruh)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Sembunyikan avatar dan perubahan nama layar</string>
-    <string name="settings_disable_markdown">Nonaktifkan format markdown ketika mengirim</string>
     <string name="settings_vibrate_on_mention">Bergetar ketika disebut</string>
     <string name="settings_preview_media_before_sending">Pratinjau media sebelum dikirim</string>
 

--- a/vector/src/main/res/values-in/strings.xml
+++ b/vector/src/main/res/values-in/strings.xml
@@ -551,8 +551,8 @@ Perhatikan bahwa tindakan ini akan memulai ulang aplikasi dan mungkin cukup mema
     <string name="settings_add_email_address">Tambahkan alamat email</string>
     <string name="settings_phone_number">Telepon</string>
     <string name="settings_add_phone_number">Tambahkan nomor telepon</string>
-    <string name="settings_summary_app_info_link">Layar info sistem aplikasi</string>
-    <string name="settings_title_app_info_link">Info aplikasi</string>
+    <string name="settings_app_info_link_summary">Layar info sistem aplikasi</string>
+    <string name="settings_app_info_link_title">Info aplikasi</string>
 
     <string name="settings_notification_privacy">Kerahasiaan pemberitahuan</string>
     <string name="settings_notification_privacy_warning">Riot.im beroperasi di balik layar untuk menjaga kerahasiaan isi pesan pemberitahuan. Anda dapat mengubah pengaturan untuk mengurangi penggunaan baterai.</string>
@@ -874,7 +874,7 @@ Peringatan: berkas ini mungkin ikut terhapus jika aplikasi dihapus.</string>
     <string name="settings_copyright">Hak Cipta</string>
     <string name="settings_privacy_policy">Kebijakan Pribadi</string>
     <string name="settings_clear_cache">Bersihkan cache</string>
-    <string name="settings_clear_medias_cache">Bersihkan cache media</string>
+    <string name="settings_clear_media_cache">Bersihkan cache media</string>
     <string name="settings_keep_media">Pertahankan media</string>
 
     <string name="settings_user_settings">Pengaturan pengguna</string>

--- a/vector/src/main/res/values-is/strings.xml
+++ b/vector/src/main/res/values-is/strings.xml
@@ -275,8 +275,8 @@
     <string name="settings_add_email_address">Bæta við tölvupóstfangi</string>
     <string name="settings_phone_number">Símanúmer</string>
     <string name="settings_add_phone_number">Bæta við símanúmeri</string>
-    <string name="settings_summary_app_info_link">Kerfisupplýsingar forrits</string>
-    <string name="settings_title_app_info_link">Upplýsingar um forrit</string>
+    <string name="settings_app_info_link_summary">Kerfisupplýsingar forrits</string>
+    <string name="settings_app_info_link_title">Upplýsingar um forrit</string>
 
     <string name="settings_second">sekúnda</string>
     <string name="settings_seconds">sekúndur</string>
@@ -288,7 +288,7 @@
     <string name="settings_copyright">Höfundarréttur</string>
     <string name="settings_privacy_policy">Meðferð persónuupplýsinga</string>
     <string name="settings_clear_cache">Hreinsa skyndiminni</string>
-    <string name="settings_clear_medias_cache">Hreinsa skyndiminni margmiðlunarefnis</string>
+    <string name="settings_clear_media_cache">Hreinsa skyndiminni margmiðlunarefnis</string>
     <string name="settings_notifications">Tilkynningar</string>
     <string name="settings_ignored_users">Hunsaðir notendur</string>
     <string name="settings_other">Annað</string>

--- a/vector/src/main/res/values-is/strings.xml
+++ b/vector/src/main/res/values-is/strings.xml
@@ -611,10 +611,8 @@
     <string name="settings_enable_background_sync">Virkja samstillingu í bakgrunnsvinnslu</string>
     <string name="settings_user_settings">Stillingar notanda</string>
     <string name="settings_contacts_app_permission">Heimildir fyrir tengiliði</string>
-    <string name="settings_hide_read_receipts">Fela leskvittanir</string>
     <string name="settings_always_show_timestamps">Alltaf birta tímamerki skilaboða</string>
     <string name="settings_12_24_timestamps">Birta tímamerki á 12 stunda sniði (t.d. 2:30 fh)</string>
-    <string name="settings_disable_markdown">Gera Markdown-stílgerð óvirka við sendingu</string>
     <string name="startup_notification_privacy_title">Friðhelgi tilkynninga</string>
     <string name="startup_notification_privacy_button_grant">Gefa heimild</string>
     <string name="startup_notification_privacy_button_other">Veldu annan valkost</string>
@@ -730,8 +728,6 @@ Ertu alveg viss?</string>
     <string name="settings_set_sync_delay">Hlé milli tveggja samstillingarbeiðna</string>
     <string name="settings_keep_media">Halda gögnum</string>
 
-    <string name="settings_hide_join_leave_messages">Fela taka-þátt/hætta skilaboð (hefur ekki áhrif á boð/spörk/bönn)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Fela breytingar á auðkennismynd og birtingarnafni</string>
     <string name="startup_notification_privacy_message">Riot getur keyrt í bakgrunni og stýrt tilkynningum á öruggan hátt (getur haft áhrif á rafhlöðunotkun).</string>
 
     <string name="account_email_validation_message">Skoðaðu tölvupóstinn þinn og smelltu á tengilinn sem hann inniheldur. Þegar því er lokið skaltu smella á að halda áfram.</string>
@@ -841,5 +837,4 @@ Tölvupóstfang nýtist einnig til að endurstilla lykilorðið þitt.</string>
     <string name="widget_integration_missing_parameter">Nauðsynlegt gildi vantar.</string>
     <string name="widget_integration_invalid_parameter">Gildið er ekki gilt.</string>
 
-<string name="settings_dont_send_typings_notifs">Ekki senda skrunandi tilkynningar</string>
-    </resources>
+</resources>

--- a/vector/src/main/res/values-it/strings.xml
+++ b/vector/src/main/res/values-it/strings.xml
@@ -460,8 +460,8 @@ Tieni presente che questa azione riavvierà l\'app e potrebbe richiedere del tem
     <string name="settings_add_email_address">Aggiungi indirizzo email</string>
     <string name="settings_phone_number">Telefono</string>
     <string name="settings_add_phone_number">Aggiungi numero di telefono</string>
-    <string name="settings_summary_app_info_link">Informazioni di sistema per l\'applicazione</string>
-    <string name="settings_title_app_info_link">Informazioni applicazione</string>
+    <string name="settings_app_info_link_summary">Informazioni di sistema per l\'applicazione</string>
+    <string name="settings_app_info_link_title">Informazioni applicazione</string>
 
     <string name="settings_enable_all_notif">Abilita notifiche per questo account</string>
     <string name="settings_enable_this_device">Abilita notifiche per questo dispositivo</string>
@@ -488,7 +488,7 @@ Tieni presente che questa azione riavvierà l\'app e potrebbe richiedere del tem
     <string name="settings_copyright">Copyright</string>
     <string name="settings_privacy_policy">Politica sulla privacy</string>
     <string name="settings_clear_cache">Elimina cache</string>
-    <string name="settings_clear_medias_cache">Elimina file multimediali temporanei</string>
+    <string name="settings_clear_media_cache">Elimina file multimediali temporanei</string>
     <string name="settings_keep_media">Conserva file multimediali</string>
 
     <string name="settings_user_settings">Impostazioni utente</string>

--- a/vector/src/main/res/values-it/strings.xml
+++ b/vector/src/main/res/values-it/strings.xml
@@ -505,10 +505,7 @@ Tieni presente che questa azione riavvierà l\'app e potrebbe richiedere del tem
     <string name="settings_pin_missed_notifications">Segna le stanze con notifiche perse</string>
     <string name="settings_pin_unread_messages">Segna le stanze con messaggi non letti</string>
     <string name="settings_devices_list">Dispositivi</string>
-    <string name="settings_hide_read_receipts">Nascondi conferme di lettura</string>
-    <string name="settings_dont_send_typings_notifs">Non comunicare che stai scrivendo</string>
     <string name="settings_always_show_timestamps">Mostra sempre data e ora dei messaggi</string>
-    <string name="settings_disable_markdown">Disattiva la formattazione markdown quando si invia</string>
     <string name="settings_data_save_mode">Modalità risparmio banda</string>
 
     <string name="devices_details_dialog_title">Dettagli dispositivo</string>
@@ -760,7 +757,6 @@ In futuro il processo di verifica sarà più sofisticato.</string>
 
     <string name="settings_containing_my_display_name">Msg contenenti il nome mostrato</string>
     <string name="settings_containing_my_user_name">Msg contenenti il nome utente</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Nascondi cambiamenti del nome mostrato e dell\'avatar</string>
 
     <string name="notification_silent_notifications">Notifiche silenziose</string>
 
@@ -829,7 +825,6 @@ In futuro il processo di verifica sarà più sofisticato.</string>
     <string name="room_settings_add_homescreen_shortcut">Aggiungi scorciatoia su schermata iniziale</string>
 
     <string name="settings_inline_url_preview">Attiva l\'anteprima degli URL in via predefinita</string>
-    <string name="settings_hide_join_leave_messages">Nascondi messaggi entrato/uscito (non si applica a invita/butta-fuori/bandisci)</string>
     <string name="settings_vibrate_on_mention">Vibra quando ti citano</string>
 
     <string name="settings_analytics">Statistiche</string>

--- a/vector/src/main/res/values-ja/strings.xml
+++ b/vector/src/main/res/values-ja/strings.xml
@@ -214,14 +214,9 @@
     <string name="settings_contacts_app_permission">端末の電話帳の使用を許可</string>
     <string name="settings_contacts_phonebook_country">電話帳の国番号</string>
     <string name="settings_devices_list">端末</string>
-    <string name="settings_hide_read_receipts">既読通知を表示しない</string>
-    <string name="settings_dont_send_typings_notifs">発言入力中であることを公表しない</string>
     <string name="settings_always_show_timestamps">発言時刻を常に表示</string>
     <string name="settings_12_24_timestamps">発言時刻を12時間形式で表示 (例 午後2:30)</string>
-    <string name="settings_hide_join_leave_messages">参加や退室の文を表示しない(招待,強制退室,再入室禁止は表示)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">アイコン画像や表示名の変更を表示しない</string>
 
-    <string name="settings_disable_markdown">markdown書式表示を不許可</string>
     <string name="devices_details_dialog_title">端末詳細</string>
     <string name="devices_details_id_title">ID(端末固有番号)</string>
     <string name="devices_details_name_title">端末名</string>

--- a/vector/src/main/res/values-ja/strings.xml
+++ b/vector/src/main/res/values-ja/strings.xml
@@ -200,7 +200,7 @@
     <string name="settings_set_sync_timeout">新着確認を失敗とするまでの時間</string>
     <string name="settings_set_sync_delay">再度新着確認を送るまでの時間</string>
     <string name="settings_clear_cache">一時保存を消去</string>
-    <string name="settings_clear_medias_cache">画像等の一時保存を消去</string>
+    <string name="settings_clear_media_cache">画像等の一時保存を消去</string>
     <string name="settings_keep_media">画像等を一時保存する期間</string>
 
     <string name="settings_user_settings">利用者設定</string>
@@ -651,8 +651,8 @@ Riotアプリがあなたの電話帳へアクセスすることを許可しま�
     <string name="directory_searching_title">ディレクトリを検索中..</string>
 
     <string name="room_sliding_menu_third_party_notices">サードパーティのライセンスに関する通知</string>
-    <string name="settings_summary_app_info_link">このアプリのシステムの情報を見る</string>
-    <string name="settings_title_app_info_link">アプリの情報</string>
+    <string name="settings_app_info_link_summary">このアプリのシステムの情報を見る</string>
+    <string name="settings_app_info_link_title">アプリの情報</string>
 
     <string name="settings_containing_my_display_name">自分の名前を含むメッセージ</string>
     <string name="settings_containing_my_user_name">自分のユーザネームを含むメッセージ</string>

--- a/vector/src/main/res/values-lv/strings.xml
+++ b/vector/src/main/res/values-lv/strings.xml
@@ -458,8 +458,8 @@ Vai vēlies turpināt?</string>
     <string name="settings_add_email_address">Pievienot epasta adresi</string>
     <string name="settings_phone_number">Tālrunis</string>
     <string name="settings_add_phone_number">Pievienot tālruņa #</string>
-    <string name="settings_summary_app_info_link">Doties uz Android Lietotņu informācijas sadaļu</string>
-    <string name="settings_title_app_info_link">Lietotnes informācija</string>
+    <string name="settings_app_info_link_summary">Doties uz Android Lietotņu informācijas sadaļu</string>
+    <string name="settings_app_info_link_title">Lietotnes informācija</string>
 
     <string name="settings_notification_ringtone">Paziņojumu skaņa</string>
     <string name="settings_enable_all_notif">Iespējot šim kontam paziņojumus</string>
@@ -489,7 +489,7 @@ Vai vēlies turpināt?</string>
     <string name="settings_copyright">Autortiesības</string>
     <string name="settings_privacy_policy">Privātuma politika</string>
     <string name="settings_clear_cache">Iztīrīt ķešu</string>
-    <string name="settings_clear_medias_cache">Iztīrīt mēdija ķešu</string>
+    <string name="settings_clear_media_cache">Iztīrīt mēdija ķešu</string>
     <string name="settings_keep_media">Turēt mēdiju (?)</string>
 
     <string name="settings_user_settings">Lietotāja iestatījumi</string>

--- a/vector/src/main/res/values-lv/strings.xml
+++ b/vector/src/main/res/values-lv/strings.xml
@@ -507,13 +507,8 @@ Vai vēlies turpināt?</string>
     <string name="settings_pin_unread_messages">Piestiprināt istabas ar neizlasītām ziņām</string>
     <string name="settings_devices_list">Ierīces</string>
     <string name="settings_inline_url_preview">Iespējot URL priekšskatu pēc noklusējuma</string>
-    <string name="settings_hide_read_receipts">Nerādīt atzīmes, ka ziņu esmu izlasījis</string>
-    <string name="settings_dont_send_typings_notifs">Nerādīt paziņojumu par to, ka rakstu</string>
     <string name="settings_always_show_timestamps">Vienmēr rādīt ziņu laiku</string>
     <string name="settings_12_24_timestamps">Rādīt ziņu laiku 12 stundu formātā (piem. 12:12pm)</string>
-    <string name="settings_hide_join_leave_messages">Slēpt \"pievienojās/atstāja\" istabu paziņojumus (neietekmē uzaicinājumus/izsperšanu/nobanošanu)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Nerādīt avatara un rādāmā vārdā izmaiņas</string>
-    <string name="settings_disable_markdown">Atspējot \"markdown\" formatēšanu nosūtāmajām ziņām</string>
     <string name="settings_vibrate_on_mention">Vibrācija, kad pieminējums</string>
 
     <string name="settings_analytics">Analītika</string>

--- a/vector/src/main/res/values-nl/strings.xml
+++ b/vector/src/main/res/values-nl/strings.xml
@@ -693,10 +693,7 @@ Je kan het nu, of later, doen vanuit de programma-instellingen.</string>
     <string name="settings_clear_medias_cache">Media cache vrijmaken</string>
     <string name="settings_keep_media">Media behouden</string>
 
-    <string name="settings_hide_read_receipts">Leesbewijzen verbergen</string>
-    <string name="settings_dont_send_typings_notifs">Geen typ notificaties versturen</string>
     <string name="settings_always_show_timestamps">Altijd tijden van berichten weergeven</string>
-    <string name="settings_disable_markdown">Tekst formattering uitzetten wanneer je berichten verstuurd</string>
     <string name="settings_data_save_mode">Data bespaarmodus</string>
 
     <string name="settings_user_interface">Gebruikersinterface</string>
@@ -729,8 +726,6 @@ Je kan het nu, of later, doen vanuit de programma-instellingen.</string>
 
     <string name="settings_notification_ringtone">Notificatie geluid</string>
     <string name="settings_12_24_timestamps">Tijdsaanduidingen in 12 uur formaat weergeven (bv. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Toetreden/verlaten berichten verbergen (uitnodigingen/uitzettingen/verbanningen blijven zichtbaar)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Profielfoto en weergavenaam veranderingen verbergen</string>
 
     <string name="widget_no_power_to_manage">Je hebt permissie nodig om widgets in deze ruimte te beheren</string>
     <string name="widget_creation_failure">Het maken van de widget is niet goed gegaan</string>

--- a/vector/src/main/res/values-nl/strings.xml
+++ b/vector/src/main/res/values-nl/strings.xml
@@ -435,8 +435,8 @@ Let op: deze actie zal de app opnieuw opstarten, en kan enige tijd kosten.</stri
     <string name="settings_add_email_address">E-mailadres toevoegen</string>
     <string name="settings_phone_number">Telefoonnummer</string>
     <string name="settings_add_phone_number">Add phone number</string>
-    <string name="settings_summary_app_info_link">Applicatiesysteem informatiescherm</string>
-    <string name="settings_title_app_info_link">Applicatie informatie</string>
+    <string name="settings_app_info_link_summary">Applicatiesysteem informatiescherm</string>
+    <string name="settings_app_info_link_title">Applicatie informatie</string>
 
     <string name="settings_enable_all_notif">Notificaties voor dit account aanzetten</string>
     <string name="settings_enable_this_device">Notificaties voor dit apparaat aanzetten</string>
@@ -690,7 +690,7 @@ Je kan het nu, of later, doen vanuit de programma-instellingen.</string>
     <string name="user_directory_header">Gebruikersadresboek</string>
     <string name="people_search_user_directory">GEBRUIKERSADRESBOEK (%s)</string>
     <string name="settings_start_on_boot">Start bij het inschakelen van je telefoon</string>
-    <string name="settings_clear_medias_cache">Media cache vrijmaken</string>
+    <string name="settings_clear_media_cache">Media cache vrijmaken</string>
     <string name="settings_keep_media">Media behouden</string>
 
     <string name="settings_always_show_timestamps">Altijd tijden van berichten weergeven</string>

--- a/vector/src/main/res/values-nn/strings.xml
+++ b/vector/src/main/res/values-nn/strings.xml
@@ -511,8 +511,8 @@ Merk at denne handlinga vil starta æppen på nytt og kan taka litt tid.</string
     <string name="settings_add_email_address">Legg ei epostadresse til</string>
     <string name="settings_phone_number">Telefon</string>
     <string name="settings_add_phone_number">Legg eit telefonnummer til</string>
-    <string name="settings_summary_app_info_link">Æppsystem-infoskjerm</string>
-    <string name="settings_title_app_info_link">Æppinfo</string>
+    <string name="settings_app_info_link_summary">Æppsystem-infoskjerm</string>
+    <string name="settings_app_info_link_title">Æppinfo</string>
 
     <string name="settings_notification_privacy">Varselpersonvern</string>
     <string name="settings_notification_privacy_warning">Riot.im køyrer i bakgrunnen for å halde varselinnhaldet ditt privat. Du kan forandra på denne innstillinga for å senka batteribruket.</string>
@@ -556,7 +556,7 @@ Merk at denne handlinga vil starta æppen på nytt og kan taka litt tid.</string
     <string name="settings_copyright">Opphavsrett</string>
     <string name="settings_privacy_policy">Personvernsretningsliner</string>
     <string name="settings_clear_cache">Tøm buffar</string>
-    <string name="settings_clear_medias_cache">Tøm mediabuffar</string>
+    <string name="settings_clear_media_cache">Tøm mediabuffar</string>
     <string name="settings_keep_media">Hald på mediet</string>
 
     <string name="settings_user_settings">Brukarinnstillingar</string>

--- a/vector/src/main/res/values-nn/strings.xml
+++ b/vector/src/main/res/values-nn/strings.xml
@@ -574,13 +574,8 @@ Merk at denne handlinga vil starta æppen på nytt og kan taka litt tid.</string
     <string name="settings_pin_unread_messages">Fest rom med uleste meldingar</string>
     <string name="settings_devices_list">Einingar</string>
     <string name="settings_inline_url_preview">Skru URL-førehandsvisingar i tekstfeltet på</string>
-    <string name="settings_hide_read_receipts">Gøym lest-lappar</string>
-    <string name="settings_dont_send_typings_notifs">Ikkje send skrivevarsel</string>
     <string name="settings_always_show_timestamps">Vis alltid meldingstidspunkt</string>
     <string name="settings_12_24_timestamps">Vis tidspunkt i 12-timarsform (t.d. 4:20pm)</string>
-    <string name="settings_hide_join_leave_messages">Gøym kom inn/fór ut-meldingar (innbyding/utsparking/utestenging påverkast ikkje)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Gøym avatar- og visingsnamnforandringar</string>
-    <string name="settings_disable_markdown">Skru markdown-teiknsetjing av ved avsending</string>
     <string name="settings_vibrate_on_mention">Rist ved nemning</string>
     <string name="settings_preview_media_before_sending">Førehandsvis medium før avsending</string>
 

--- a/vector/src/main/res/values-pl/strings.xml
+++ b/vector/src/main/res/values-pl/strings.xml
@@ -392,10 +392,7 @@ Zauważ, że ta czynność spowoduje ponowne uruchomienie aplikacji i może to t
     <string name="settings_pin_missed_notifications">Przypnij pokoje z ominiętymi powiadomieniami</string>
     <string name="settings_pin_unread_messages">Przypnij pokoje z nieprzeczytanych wiadomościami</string>
     <string name="settings_devices_list">Urządzenia</string>
-    <string name="settings_hide_read_receipts">Nie pokazuj potwierdzeń o przeczytaniu</string>
-    <string name="settings_dont_send_typings_notifs">Nie informuj użytkowników, gdy piszesz</string>
     <string name="settings_always_show_timestamps">Zawsze pokazuj czas wysłania wiadomości</string>
-    <string name="settings_disable_markdown">Wyłącz formatowanie Markdown podczas wysyłania</string>
     <string name="settings_data_save_mode">Tryb oszczędzania danych</string>
 
     <string name="devices_details_dialog_title">Szczegóły o urządzeniu</string>
@@ -710,8 +707,6 @@ Jesteś pewien?</string>
     <string name="settings_home_display">Ekran domowy</string>
     <string name="settings_inline_url_preview">Zezwól na domyślny podgląd zawartości URL</string>
     <string name="settings_12_24_timestamps">Pokaż czas w formacie 12 godzinnym (np. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Ukryj wiadomości o dołączeniu/wyjściu (zaproszenia, wyproszenia, blokowanie nie zostaną ukryte)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Ukryj awatar i zmiany wyświetlanej nazwy</string>
     <string name="settings_vibrate_on_mention">Wibruj gdy ktoś wspomni o tobie</string>
 
     <string name="settings_analytics">Analityka</string>

--- a/vector/src/main/res/values-pl/strings.xml
+++ b/vector/src/main/res/values-pl/strings.xml
@@ -357,7 +357,7 @@ Zauważ, że ta czynność spowoduje ponowne uruchomienie aplikacji i może to t
     <string name="settings_add_email_address">Dodaj adres e-mail</string>
     <string name="settings_phone_number">Numer telefonu</string>
     <string name="settings_add_phone_number">Dodaj numer telefonu</string>
-    <string name="settings_title_app_info_link">Informacje o aplikacji</string>
+    <string name="settings_app_info_link_title">Informacje o aplikacji</string>
 
     <string name="settings_enable_all_notif">Włącz powiadomienia dla tego konta</string>
     <string name="settings_enable_this_device">Włącz powiadomienia dla tego użytkownika</string>
@@ -380,7 +380,7 @@ Zauważ, że ta czynność spowoduje ponowne uruchomienie aplikacji i może to t
     <string name="settings_copyright">Prawa autorskie</string>
     <string name="settings_privacy_policy">Polityka prywatności</string>
     <string name="settings_clear_cache">Wyczyść pamięć podręczną</string>
-    <string name="settings_clear_medias_cache">Wyczyść pamięć podręczną multimediów</string>
+    <string name="settings_clear_media_cache">Wyczyść pamięć podręczną multimediów</string>
     <string name="settings_user_settings">Ustawienia użytkownika</string>
     <string name="settings_notifications">Powiadomienia</string>
     <string name="settings_ignored_users">Ignorowani użytkownicy</string>
@@ -693,7 +693,7 @@ Jesteś pewien?</string>
     <string name="room_settings_add_homescreen_shortcut">Dodaj skrót do ekranu domowego</string>
 
     <string name="room_sliding_menu_third_party_notices">Informacje o trzecich stronach</string>
-    <string name="settings_summary_app_info_link">Ekran informacji systemowych aplikacji</string>
+    <string name="settings_app_info_link_summary">Ekran informacji systemowych aplikacji</string>
     <string name="settings_notification_ringtone">Dźwięk powiadomień</string>
     <string name="settings_containing_my_display_name">Wiadomości zawierające moją wyświetlaną nazwę</string>
     <string name="settings_containing_my_user_name">Wiadomości zawierające moją nazwę użytkownika</string>

--- a/vector/src/main/res/values-pt-rBR/strings.xml
+++ b/vector/src/main/res/values-pt-rBR/strings.xml
@@ -685,10 +685,7 @@ No futuro, este processo de verificação será mais sofisticado.</string>
     <string name="settings_clear_medias_cache">Esvaziar o cache de mídia</string>
     <string name="settings_keep_media">Manter mídia</string>
 
-    <string name="settings_hide_read_receipts">Ocultar recibos de leitura</string>
-    <string name="settings_dont_send_typings_notifs">Não enviar notificações de digitação</string>
     <string name="settings_always_show_timestamps">Sempre mostrar a hora das mensagens</string>
-    <string name="settings_disable_markdown">Desabilitar formatação Markdown quando estiver enviando</string>
     <string name="settings_data_save_mode">Modo de economia de dados</string>
 
     <string name="settings_user_interface">Interface de usuária(o)</string>
@@ -759,8 +756,6 @@ No futuro, este processo de verificação será mais sofisticado.</string>
     <string name="settings_containing_my_user_name">Mensagens que contenham o meu nome de usuária(o)</string>
     <string name="settings_inline_url_preview">Habilitar visualização resumida dos links por padrão</string>
     <string name="settings_12_24_timestamps">Utilizar o formato de 12 horas (p.ex: 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Ocultar mensagens de entrada e de saída de pessoas (convites, expulsões e banimentos não são afetados)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Ocultar mensagens de alteração de avatar e de nome público</string>
     <string name="settings_vibrate_on_mention">Vibrar quando mencionado</string>
 
     <string name="settings_analytics">Estatísticas de uso</string>

--- a/vector/src/main/res/values-pt-rBR/strings.xml
+++ b/vector/src/main/res/values-pt-rBR/strings.xml
@@ -436,8 +436,8 @@ Note que esta ação irá reiniciar o aplicativo e poderá tomar um certo tempo.
     <string name="settings_add_email_address">Adicionar endereço de email</string>
     <string name="settings_phone_number">Telefone</string>
     <string name="settings_add_phone_number">Adicionar número de telefone</string>
-    <string name="settings_summary_app_info_link">Tela de informações sobre o sistema do aplicativo</string>
-    <string name="settings_title_app_info_link">Informações sobre o aplicativo</string>
+    <string name="settings_app_info_link_summary">Tela de informações sobre o sistema do aplicativo</string>
+    <string name="settings_app_info_link_title">Informações sobre o aplicativo</string>
 
     <string name="settings_enable_all_notif">Habilitar notificações para esta conta</string>
     <string name="settings_enable_this_device">Habilitar notificações para este dispositivo</string>
@@ -682,7 +682,7 @@ No futuro, este processo de verificação será mais sofisticado.</string>
     <string name="user_directory_header">Lista de usuárias(os)</string>
     <string name="people_search_user_directory">LISTA DE USUÁRIAS(OS) (%s)</string>
     <string name="settings_start_on_boot">Iniciar na inicialização do celular</string>
-    <string name="settings_clear_medias_cache">Esvaziar o cache de mídia</string>
+    <string name="settings_clear_media_cache">Esvaziar o cache de mídia</string>
     <string name="settings_keep_media">Manter mídia</string>
 
     <string name="settings_always_show_timestamps">Sempre mostrar a hora das mensagens</string>

--- a/vector/src/main/res/values-pt/strings.xml
+++ b/vector/src/main/res/values-pt/strings.xml
@@ -712,10 +712,7 @@ Dispositivos desconhecidos:</string>
     <string name="historical_placeholder">Procurar histórico</string>
 <string name="settings_keep_media">Manter ficheiros multimédia</string>
 
-    <string name="settings_hide_read_receipts">Ocultar recibos de leitura</string>
-    <string name="settings_dont_send_typings_notifs">Não enviar notificações de escrita</string>
     <string name="settings_always_show_timestamps">Mostrar sempre a hora das mensagens</string>
-    <string name="settings_disable_markdown">Desactivar a formatação Markdown quando estiver a enviar</string>
     <string name="settings_data_save_mode">Modo de poupança de dados</string>
 
     <string name="settings_user_interface">Interface de utilizador</string>
@@ -751,8 +748,6 @@ Dispositivos desconhecidos:</string>
 
     <string name="settings_notification_ringtone">Som de notificação</string>
     <string name="settings_12_24_timestamps">Utilizar formato de 12 horas (ex. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Ocultar mensagens de entrada/saída (convites/expulsões/banimentos não são afetados)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Ocultar avatar e mostrar mudanças de nome</string>
 
     <string name="widget_no_power_to_manage">Precisa de permissão para gerir os widgets nesta sala</string>
     <string name="widget_creation_failure">Criação de widget falhou</string>

--- a/vector/src/main/res/values-pt/strings.xml
+++ b/vector/src/main/res/values-pt/strings.xml
@@ -455,8 +455,8 @@ Note que esta acção irá reiniciar a aplicação e poderá levar algum tempo.<
     <string name="settings_add_email_address">Adicionar endereço de e-mail</string>
     <string name="settings_phone_number">Telefone</string>
     <string name="settings_add_phone_number">Adicionar número de telefone</string>
-    <string name="settings_summary_app_info_link">Ecrã de informações de sistema da aplicação</string>
-    <string name="settings_title_app_info_link">Informações da aplicação</string>
+    <string name="settings_app_info_link_summary">Ecrã de informações de sistema da aplicação</string>
+    <string name="settings_app_info_link_title">Informações da aplicação</string>
 
     <string name="settings_enable_all_notif">Ativar notificações para esta conta</string>
     <string name="settings_enable_this_device">Ativar notificações para este dispositivo</string>
@@ -739,7 +739,7 @@ Dispositivos desconhecidos:</string>
     <string name="user_directory_header">Lista de utilizadores</string>
     <string name="people_search_user_directory">LISTA DE UTILIZADORES (%s)</string>
     <string name="settings_start_on_boot">Iniciar no arranque</string>
-    <string name="settings_clear_medias_cache">Limpar cache de multimédia</string>
+    <string name="settings_clear_media_cache">Limpar cache de multimédia</string>
     <string name="light_theme">Tema Claro</string>
     <string name="dark_theme">Tema Escuro</string>
     <string name="black_them">Tema Preto</string>

--- a/vector/src/main/res/values-ru/strings.xml
+++ b/vector/src/main/res/values-ru/strings.xml
@@ -708,10 +708,7 @@ Email также позволит вам при необходимости во�
     <string name="settings_select_language">Выберите язык</string>
 
     <string name="settings_start_on_boot">Запускать при загрузке</string>
-    <string name="settings_hide_read_receipts">Скрыть отметки о прочтении</string>
-    <string name="settings_dont_send_typings_notifs">Не оповещать, когда я печатаю</string>
     <string name="settings_always_show_timestamps">Всегда показывать временные метки сообщений</string>
-    <string name="settings_disable_markdown">Отключить Markdown-форматирование при отправке</string>
 
     <string name="media_saving_period_3_days">3 дня</string>
     <string name="media_saving_period_1_week">1 неделя</string>
@@ -745,8 +742,6 @@ Email также позволит вам при необходимости во�
     <string name="settings_12_24_timestamps">Показывать временные метки в 12-часовом формате (например 2:30pm)</string>
     <string name="event_formatter_widget_added">%1$s добавлен %2$s</string>
     <string name="event_formatter_widget_removed">%1$s удален %2$s</string>
-    <string name="settings_hide_join_leave_messages">Скрывать сообщения присоединился/покинул (не затрагивает приглашение/кик/бан)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Скрывать изменения аватара и отображаемого имени</string>
 
     <string name="widget_no_power_to_manage">Вам нужно разрешение на управление виджетами в этой комнате</string>
     <string name="widget_creation_failure">Создание виджета не удалось</string>

--- a/vector/src/main/res/values-ru/strings.xml
+++ b/vector/src/main/res/values-ru/strings.xml
@@ -446,8 +446,8 @@ Email также позволит вам при необходимости во�
     <string name="settings_add_email_address">Добавить email</string>
     <string name="settings_phone_number">Телефон</string>
     <string name="settings_add_phone_number">Добавить телефон</string>
-    <string name="settings_summary_app_info_link">Экран системной информации приложения</string>
-    <string name="settings_title_app_info_link">Сведения о приложении</string>
+    <string name="settings_app_info_link_summary">Экран системной информации приложения</string>
+    <string name="settings_app_info_link_title">Сведения о приложении</string>
     
     <string name="settings_enable_all_notif">Включить уведомления для этой учетной записи</string>
     <string name="settings_enable_this_device">Включить уведомления для этого устройства</string>
@@ -715,7 +715,7 @@ Email также позволит вам при необходимости во�
     <string name="media_saving_period_1_month">1 месяц</string>
     <string name="media_saving_period_forever">Постоянно</string>
 
-    <string name="settings_clear_medias_cache">Очистить медиа кэш</string>
+    <string name="settings_clear_media_cache">Очистить медиа кэш</string>
     <string name="offline">Недоступен</string>
 
     <string name="user_directory_header">Каталог пользователей</string>

--- a/vector/src/main/res/values-sk/strings.xml
+++ b/vector/src/main/res/values-sk/strings.xml
@@ -474,14 +474,9 @@ Pozor! Vykonaním tejto akcie reštartujete aplikáciu a opätovné načítanie 
     <string name="settings_pin_missed_notifications">Pripnúť miestnosti so zmeškanými oznámeniami</string>
     <string name="settings_pin_unread_messages">Pripnúť miestnosti s neprečítanými správami</string>
     <string name="settings_devices_list">Zariadenia</string>
-    <string name="settings_hide_read_receipts">Skryť upozornenia o prečítaní</string>
-    <string name="settings_dont_send_typings_notifs">Neposielať oznámenia keď píšete</string>
     <string name="settings_always_show_timestamps">Vždy zobrazovať časovú značku správ</string>
     <string name="settings_12_24_timestamps">Pri zobrazovaní časových značiek používať 12 hodinový formát (napr. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Skryť správy o vstupe a opustení miestnosti (netýka sa pozvaní/vykázaní/zákazov vstupu)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Skryť zmeny zobrazovaného mena a obrázka v profile</string>
 
-    <string name="settings_disable_markdown">Pri odosielaní zakázať formátovanie textu Markdown</string>
     <string name="settings_data_save_mode">Režim šetrenia údajov</string>
 
     <string name="devices_details_dialog_title">Podrobnosti o zariadení</string>

--- a/vector/src/main/res/values-sk/strings.xml
+++ b/vector/src/main/res/values-sk/strings.xml
@@ -426,8 +426,8 @@ Pozor! Vykonaním tejto akcie reštartujete aplikáciu a opätovné načítanie 
     <string name="settings_add_email_address">Pridať emailovú adresu</string>
     <string name="settings_phone_number">Telefón</string>
     <string name="settings_add_phone_number">Pridať telefónne číslo</string>
-    <string name="settings_summary_app_info_link">Systémová obrazovka s informáciami o aplikácii</string>
-    <string name="settings_title_app_info_link">Info o aplikácii</string>
+    <string name="settings_app_info_link_summary">Systémová obrazovka s informáciami o aplikácii</string>
+    <string name="settings_app_info_link_title">Info o aplikácii</string>
 
     <string name="settings_notification_ringtone">Zvuk oznámení</string>
     <string name="settings_enable_all_notif">Povoliť oznámenia pre tento účet</string>
@@ -457,7 +457,7 @@ Pozor! Vykonaním tejto akcie reštartujete aplikáciu a opätovné načítanie 
     <string name="settings_copyright">Autorské práva</string>
     <string name="settings_privacy_policy">Pravidlá ochrany súkromia</string>
     <string name="settings_clear_cache">Vyprázdniť vyrovnávaciu pamäť</string>
-    <string name="settings_clear_medias_cache">Vyprázdniť vyrovnávaciu pamäť s médiami</string>
+    <string name="settings_clear_media_cache">Vyprázdniť vyrovnávaciu pamäť s médiami</string>
     <string name="settings_keep_media">Ponechať médiá</string>
 
     <string name="settings_user_settings">Používateľské nastavenia</string>

--- a/vector/src/main/res/values-te/strings.xml
+++ b/vector/src/main/res/values-te/strings.xml
@@ -320,7 +320,7 @@
     <string name="settings_add_email_address">ఇమెయిల్ చిరునామాను జోడించండి</string>
     <string name="settings_phone_number">ఫోన్</string>
     <string name="settings_add_phone_number">ఫోన్ నంబర్ను జోడించండి</string>
-    <string name="settings_title_app_info_link">అప్లికేషన్ సమాచారం</string>
+    <string name="settings_app_info_link_title">అప్లికేషన్ సమాచారం</string>
 
     <string name="settings_messages_in_group_chat">గుంపు చాట్లలోని సందేశాలు</string>
     <string name="settings_invited_to_room">నేను ఒక గదికి ఆహ్వానించబడినప్పుడు</string>

--- a/vector/src/main/res/values-uk/strings.xml
+++ b/vector/src/main/res/values-uk/strings.xml
@@ -443,8 +443,8 @@
     <string name="settings_add_email_address">Додати email</string>
     <string name="settings_phone_number">Телефон</string>
     <string name="settings_add_phone_number">Додати номер телефону</string>
-    <string name="settings_summary_app_info_link">Екран системної інформації застосунку</string>
-    <string name="settings_title_app_info_link">Про застосунок</string>
+    <string name="settings_app_info_link_summary">Екран системної інформації застосунку</string>
+    <string name="settings_app_info_link_title">Про застосунок</string>
 
     <string name="settings_notification_ringtone">Тон сповіщення</string>
     <string name="settings_enable_all_notif">Увімкнути сповіщення для цього облікового запису</string>
@@ -474,7 +474,7 @@
     <string name="settings_copyright">Copyright</string>
     <string name="settings_privacy_policy">Політика конфіденційності</string>
     <string name="settings_clear_cache">Очистити кеш</string>
-    <string name="settings_clear_medias_cache">Очистити медіа кеш</string>
+    <string name="settings_clear_media_cache">Очистити медіа кеш</string>
     <string name="settings_keep_media">Зберігати медіа</string>
 
     <string name="settings_user_settings">Налаштування користувача</string>

--- a/vector/src/main/res/values-uk/strings.xml
+++ b/vector/src/main/res/values-uk/strings.xml
@@ -491,17 +491,12 @@
     <string name="settings_pin_missed_notifications">Закріплювати кімнати з пропущеними сповіщеннями</string>
     <string name="settings_pin_unread_messages">Закріплювати кімнати з новими повідомленнями</string>
     <string name="settings_devices_list">Пристрої</string>
-    <string name="settings_hide_read_receipts">Приховати звіти про читання</string>
-    <string name="settings_dont_send_typings_notifs">Не сповіщати про набір тексту</string>
     <string name="settings_always_show_timestamps">Завжди показувати час надсилання</string>
     <string name="settings_12_24_timestamps">Показувати час надсилання в 12 годинному форматі (e.g. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Приховати сповіщення про вступ/вихід з кімнат (не діє на запрошення/кіки/бани)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Приховати аватари та показувати зміну імен</string>
 
     <!-- analytics -->
     <string name="settings_analytics">Телеметрія</string>
 
-    <string name="settings_disable_markdown">Вимкнути розмітку Markdown при відправленні</string>
     <string name="settings_data_save_mode">Режим економії трафіку</string>
 
     <string name="devices_details_dialog_title">Про пристрій</string>

--- a/vector/src/main/res/values-zh-rCN/strings.xml
+++ b/vector/src/main/res/values-zh-rCN/strings.xml
@@ -297,7 +297,7 @@
     <string name="room_sliding_menu_privacy_policy">隐私政策</string>
 
     <string name="settings_phone_number">电话号码</string>
-    <string name="settings_title_app_info_link">应用信息</string>
+    <string name="settings_app_info_link_title">应用信息</string>
 
     <string name="settings_enable_all_notif">启用这个账户的通知</string>
     <string name="settings_enable_this_device">启用这个设备的通知</string>
@@ -481,7 +481,7 @@
     <string name="room_settings_favourite">收藏夹</string>
     <string name="room_sliding_menu_term_and_conditions">使用条款</string>
     <string name="settings_display_name">昵称</string>
-    <string name="settings_summary_app_info_link">应用程序系统信息窗口</string>
+    <string name="settings_app_info_link_summary">应用程序系统信息窗口</string>
     <string name="settings_turn_screen_on">点亮屏幕 3 秒</string>
 
     <string name="settings_call_invitations">通话请求</string>
@@ -663,7 +663,7 @@
     <string name="user_directory_header">用户目录</string>
     <string name="people_search_user_directory">用户目录（%s）</string>
     <string name="settings_start_on_boot">开机时自动启动</string>
-    <string name="settings_clear_medias_cache">清空缓存的媒体文件</string>
+    <string name="settings_clear_media_cache">清空缓存的媒体文件</string>
     <string name="settings_keep_media">保留媒体文件</string>
 
     <string name="settings_always_show_timestamps">总是显示消息时间戳</string>

--- a/vector/src/main/res/values-zh-rCN/strings.xml
+++ b/vector/src/main/res/values-zh-rCN/strings.xml
@@ -666,10 +666,7 @@
     <string name="settings_clear_medias_cache">清空缓存的媒体文件</string>
     <string name="settings_keep_media">保留媒体文件</string>
 
-    <string name="settings_hide_read_receipts">隐藏已读标签</string>
-    <string name="settings_dont_send_typings_notifs">不要发送“正在输入”提示</string>
     <string name="settings_always_show_timestamps">总是显示消息时间戳</string>
-    <string name="settings_disable_markdown">发送时禁用 markdown 格式化</string>
     <string name="settings_data_save_mode">省流量模式</string>
 
     <string name="media_saving_period_3_days">3天</string>
@@ -695,8 +692,6 @@
 
     <string name="settings_notification_ringtone">通知声音</string>
     <string name="settings_12_24_timestamps">用12小时制显示时间戳（如：下午 2:30）</string>
-    <string name="settings_hide_join_leave_messages">隐藏加入/退出消息（邀请/踢出/封禁不受影响）</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">隐藏头像和显示名称的修改</string>
 
     <string name="widget_no_power_to_manage">您需要权限来管理这个聊天室的小部件</string>
     <string name="widget_creation_failure">创建小部件失败</string>

--- a/vector/src/main/res/values-zh-rTW/strings.xml
+++ b/vector/src/main/res/values-zh-rTW/strings.xml
@@ -502,8 +502,8 @@
     <string name="settings_add_email_address">新增電子郵件地址</string>
     <string name="settings_phone_number">電話號碼</string>
     <string name="settings_add_phone_number">添加電話號碼</string>
-    <string name="settings_summary_app_info_link">應用程式系統資訊畫面</string>
-    <string name="settings_title_app_info_link">應用程式資訊</string>
+    <string name="settings_app_info_link_summary">應用程式系統資訊畫面</string>
+    <string name="settings_app_info_link_title">應用程式資訊</string>
 
     <string name="settings_notification_privacy">通知隱私</string>
     <string name="settings_notification_privacy_warning">Riot.im 將在後臺運行以保持通知訊息內容的私密。您可以更改此選項以減少電池使用量。</string>
@@ -547,7 +547,7 @@
     <string name="settings_copyright">版權</string>
     <string name="settings_privacy_policy">隱私權政策</string>
     <string name="settings_clear_cache">清空暫存檔</string>
-    <string name="settings_clear_medias_cache">清除媒體暫存檔</string>
+    <string name="settings_clear_media_cache">清除媒體暫存檔</string>
     <string name="settings_keep_media">保留媒體檔案</string>
 
     <string name="settings_user_settings">使用者設定</string>

--- a/vector/src/main/res/values-zh-rTW/strings.xml
+++ b/vector/src/main/res/values-zh-rTW/strings.xml
@@ -565,13 +565,8 @@
     <string name="settings_pin_unread_messages">釘選含有未讀訊息的聊天室</string>
     <string name="settings_devices_list">裝置列表</string>
     <string name="settings_inline_url_preview">預設啟用內嵌 URL 預覽</string>
-    <string name="settings_hide_read_receipts">隱藏已讀回執</string>
-    <string name="settings_dont_send_typings_notifs">不要發送我的打字狀態</string>
     <string name="settings_always_show_timestamps">總是顯示訊息時間戳</string>
     <string name="settings_12_24_timestamps">用12小時制顯示時間戳 （如：下午 2:30）</string>
-    <string name="settings_hide_join_leave_messages">隱藏加入／離開訊息（邀請／踢出／封鎖不受影響）</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">隱藏修改個人資料圖片和顯示名稱的訊息</string>
-    <string name="settings_disable_markdown">發送訊息時不使用 Markdown 語法</string>
     <string name="settings_vibrate_on_mention">提及他人時震動</string>
 
     <string name="settings_deactivate_account_section">停用帳號</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -570,13 +570,13 @@
     <string name="settings_profile_picture">Profile Picture</string>
     <string name="settings_display_name">Display Name</string>
     <string name="settings_email_address">Email</string>
-    <string name="settings_add_email_address">Add email address</string>
+    <string name="settings_add_email_address">Add Email Address</string>
     <string name="settings_phone_number">Phone</string>
-    <string name="settings_add_phone_number">Add phone number</string>
-    <string name="settings_summary_app_info_link">Application system info screen</string>
-    <string name="settings_title_app_info_link">Application info</string>
+    <string name="settings_add_phone_number">Add Phone Number</string>
+    <string name="settings_app_info_link_title">Application Info</string>
+    <string name="settings_app_info_link_summary">Show the application info in the system settings.</string>
 
-    <string name="settings_notification_privacy">Notification privacy</string>
+    <string name="settings_notification_privacy">Notification Privacy</string>
     <string name="settings_notification_privacy_warning">Riot.im runs in the background to keep your notification message content private. You can change this option to reduce battery usage.</string>
     <string name="settings_notification_privacy_normal">Normal</string>
     <string name="settings_notification_privacy_power_saving">Power-saving Options</string>
@@ -590,24 +590,24 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Notifications contain <b>meta and message data</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Notifications will <b>not show message content</b></string>
 
-    <string name="settings_notification_ringtone">Notification sound</string>
+    <string name="settings_notification_ringtone">Notification Sound</string>
     <string name="settings_enable_all_notif">Enable notifications for this account</string>
     <string name="settings_enable_this_device">Enable notifications for this device</string>
     <string name="settings_turn_screen_on">Turn the screen on for 3 seconds</string>
 
-    <string name="settings_containing_my_display_name">Msgs containing my display name</string>
-    <string name="settings_containing_my_user_name">Msgs containing my user name</string>
-    <string name="settings_messages_in_one_to_one">Msgs in one-to-one chats</string>
-    <string name="settings_messages_in_group_chat">Msgs in group chats</string>
-    <string name="settings_invited_to_room">When i\'m invited to a room</string>
-    <string name="settings_call_invitations">Call invitations</string>
-    <string name="settings_messages_sent_by_bot">Messages sent by bot</string>
+    <string name="settings_containing_my_display_name">Display Name Mentions</string>
+    <string name="settings_containing_my_user_name">User Name Mentions</string>
+    <string name="settings_messages_in_one_to_one">One-to-One Chats</string>
+    <string name="settings_messages_in_group_chat">Group Chats</string>
+    <string name="settings_invited_to_room">Room Invitations</string>
+    <string name="settings_call_invitations">Call Invitations</string>
+    <string name="settings_messages_sent_by_bot">Bot Messages</string>
 
+    <string name="settings_background_sync">Background Synchronization</string>
     <string name="settings_start_on_boot">Start on boot</string>
-    <string name="settings_background_sync">Background synchronization</string>
     <string name="settings_enable_background_sync">Enable background sync</string>
     <string name="settings_set_sync_timeout">Sync request timeout</string>
-    <string name="settings_set_sync_delay">Delay between two sync requests</string>
+    <string name="settings_set_sync_delay">Delay between each request</string>
     <string name="settings_second">second</string>
     <string name="settings_seconds">seconds</string>
 
@@ -617,41 +617,47 @@
     <string name="settings_third_party_notices">Third party notices</string>
     <string name="settings_copyright">Copyright</string>
     <string name="settings_privacy_policy">Privacy policy</string>
-    <string name="settings_clear_cache">Clear cache</string>
-    <string name="settings_clear_medias_cache">Clear media cache</string>
-    <string name="settings_keep_media">Keep media</string>
+    <string name="settings_keep_media">Keep Media</string>
+    <string name="settings_clear_cache">Clear Cache</string>
+    <string name="settings_clear_media_cache">Clear Media Cache</string>
 
-    <string name="settings_user_settings">User settings</string>
+    <string name="settings_user_settings">User Settings</string>
     <string name="settings_notifications">Notifications</string>
     <string name="settings_ignored_users">Ignored users</string>
     <string name="settings_other">Other</string>
     <string name="settings_advanced">Advanced</string>
     <string name="settings_cryptography">Cryptography</string>
     <string name="settings_notifications_targets">Notification Targets</string>
-    <string name="settings_contact">Local contacts</string>
+    <string name="settings_contact">Local Contacts</string>
     <string name="settings_contacts_app_permission">Contacts permission</string>
-    <string name="settings_contacts_phonebook_country">Phonebook country</string>
-    <string name="settings_home_display">Home display</string>
+    <string name="settings_contacts_phonebook_country">Phonebook Country</string>
+    <string name="settings_home_display">Home Display</string>
     <string name="settings_pin_missed_notifications">Pin rooms with missed notifications</string>
     <string name="settings_pin_unread_messages">Pin rooms with unread messages</string>
     <string name="settings_devices_list">Devices</string>
-    <string name="settings_inline_url_preview">Enable inline URL previews by default</string>
-    <string name="settings_send_typing_notifs">Send typing notifications</string>
-    <string name="settings_send_markdown">Send messages with markdown formatting</string>
+    <string name="settings_inline_url_preview">Inline URL Preview</string>
+    <string name="settings_inline_url_preview_summary">Preview links within the chat when your homeserver supports this feature.</string>
+    <string name="settings_send_typing_notifs">Send Typing Notifications</string>
+    <string name="settings_send_typing_notifs_summary">Let other users know that you are typing.</string>
+    <string name="settings_send_markdown">Markdown Formatting</string>
+    <string name="settings_send_markdown_summary">Send messages with markdown when you use it for italic or bold text, among other uses.</string>
     <string name="settings_always_show_timestamps">Show timestamps for all messages</string>
     <string name="settings_12_24_timestamps">Show timestamps in twelve hour format</string>
-    <string name="settings_show_read_receipts">Show read receipts underneath messages</string>
-    <string name="settings_show_join_leave_messages">Show user join and leave messages</string>
-    <string name="settings_show_avatar_display_name_changes_messages">Show avatar and display name change messages</string>
+    <string name="settings_show_read_receipts">Show read receipts</string>
+    <string name="settings_show_read_receipts_summary">Click on the read receipts for a detailed list.</string>
+    <string name="settings_show_join_leave_messages">Show join and leave events</string>
+    <string name="settings_show_join_leave_messages_summary">Invites, kicks, and bans are unaffected.</string>
+    <string name="settings_show_avatar_display_name_changes_messages">Show account events</string>
+    <string name="settings_show_avatar_display_name_changes_messages_summary">Includes avatar and display name changes.</string>
     <string name="settings_vibrate_on_mention">Vibrate when mentioning a user</string>
     <string name="settings_preview_media_before_sending">Preview media before sending</string>
 
-    <string name="settings_deactivate_account_section">Deactivate account</string>
-    <string name="settings_deactivate_my_account">Deactivate my account</string>
+    <string name="settings_deactivate_account_section">Deactivate Account</string>
+    <string name="settings_deactivate_my_account">Deactivate Account</string>
 
     <!-- startup -->
     <string name="startup_notification_privacy_title">Notification Privacy</string>
-    <string name="startup_notification_privacy_message">Riot can run in the background to manage your notifications securely and privately (this might affect battery usage).</string>
+    <string name="startup_notification_privacy_message">Riot can run in the background to manage your notifications securely and privately. This might affect battery usage.</string>
     <string name="startup_notification_privacy_button_grant">Grant permission</string>
     <string name="startup_notification_privacy_button_other">Choose another option</string>
 
@@ -679,22 +685,23 @@
     <string name="settings_home_server">Home Server</string>
     <string name="settings_identity_server">Identity Server</string>
 
-    <string name="settings_user_interface">User interface</string>
-    <string name="settings_interface_language">Interface Language</string>
-    <string name="settings_select_language">Choose a language</string>
+    <string name="settings_user_interface">User Interface</string>
+    <string name="settings_interface_language">Language</string>
+    <string name="settings_select_language">Choose Language</string>
 
     <string name="account_email_validation_title">Verification Pending</string>
     <string name="account_email_validation_message">Please check your email and click on the link it contains. Once this is done, click continue.</string>
-    <string name="account_email_validation_error">Unable to verify email address. Please check your email and click on the link it contains. Once this is done, click continue</string>
-    <string name="account_email_already_used_error">This email address is already in use</string>
-    <string name="account_email_not_found_error">Failed to send email: This email address was not found</string>
-    <string name="account_phone_number_already_used_error">This phone number is already in use</string>
+    <string name="account_email_validation_error">Unable to verify email address. Please check your email and click on the link it contains. Once this is done, click continue.</string>
+    <string name="account_email_already_used_error">This email address is already in use.</string>
+    <string name="account_email_not_found_error">This email address was not found.</string>
+    <string name="account_phone_number_already_used_error">This phone number is already in use.</string>
 
-    <string name="settings_change_password">Change password</string>
-    <string name="settings_old_password">Old password</string>
-    <string name="settings_new_password">New password</string>
-    <string name="settings_confirm_password">Confirm password</string>
-    <string name="settings_fail_to_update_password">Fail to update password</string>
+    <string name="settings_password">Password</string>
+    <string name="settings_change_password">Change Password</string>
+    <string name="settings_old_password">Old Password</string>
+    <string name="settings_new_password">New Password</string>
+    <string name="settings_confirm_password">Confirm Password</string>
+    <string name="settings_fail_to_update_password">Failed to update password</string>
     <string name="settings_password_updated">Your password has been updated</string>
     <string name="settings_unignore_user">Show all messages from %s?\n\nNote that this action will restart the app and it may take some time.</string>
 
@@ -713,7 +720,6 @@
     <string name="settings_phone_number_verification_error_empty_code">Enter an activation code</string>
     <string name="settings_phone_number_verification_error">Error while validating your phone number</string>
     <string name="settings_phone_number_code">Code</string>
-
 
     <string name="settings_flair">Flair</string>
     <string name="settings_without_flair">You are not currently a member of any communities.</string>
@@ -842,8 +848,8 @@
     <string name="encryption_import_room_keys_summary">Import the keys from a local file</string>
     <string name="encryption_import_import">Import</string>
     <string name="encryption_import_enter_passphrase">Enter passphrase</string>
-    <string name="encryption_never_send_to_unverified_devices_title">Encrypt to verified devices only</string>
-    <string name="encryption_never_send_to_unverified_devices_summary">Never send encrypted messages to unverified devices from this device</string>
+    <string name="encryption_never_send_to_unverified_devices_title">Only message verified devices</string>
+    <string name="encryption_never_send_to_unverified_devices_summary">If a room has encryption enabled only send messages when all devices have been verified.</string>
 
     <string name="encryption_information_not_verified">NOT Verified</string>
     <string name="encryption_information_verified">Verified</string>
@@ -932,8 +938,10 @@
     <string name="widget_integration_invalid_parameter">A parameter is not valid.</string>
     <string name="room_add_matrix_apps">Add Matrix apps</string>
     <string name="settings_labs_native_camera">Use native camera</string>
+    <string name="settings_labs_native_camera_summary">Start the system camera instead of the custom camera activity.</string>
     <string name="settings_labs_keyboard_options_to_send_message">Use keyboard enter key to send message</string>
-    <string name="settings_labs_enable_send_voice">Send voice message (requires a third party application to record voice messages)</string>
+    <string name="settings_labs_enable_send_voice">Send voice messages</string>
+    <string name="settings_labs_enable_send_voice_summary">This option requires a third party application to record the messages.</string>
 
     <!-- share keys -->
     <string name="you_added_a_new_device">You added a new device \'%s\', which is requesting encryption keys.</string>
@@ -1049,7 +1057,7 @@
 
     <!-- Lazy loading -->
     <string name="settings_lazy_loading_title">Lazy load rooms members</string>
-    <string name="settings_lazy_loading_description">Increase performance by only loading room members on first view</string>
+    <string name="settings_lazy_loading_description">Increase performance by only loading room members on first view.</string>
     <string name="error_lazy_loading_not_supported_by_home_server">Your homeserver does not support lazy loading of room members yet. Try later.</string>
 
     <!-- Other errors -->

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -636,14 +636,14 @@
     <string name="settings_pin_unread_messages">Pin rooms with unread messages</string>
     <string name="settings_devices_list">Devices</string>
     <string name="settings_inline_url_preview">Enable inline URL previews by default</string>
-    <string name="settings_hide_read_receipts">Hide read receipts</string>
-    <string name="settings_dont_send_typings_notifs">Don\'t send typing notifications</string>
-    <string name="settings_always_show_timestamps">Always show message timestamps</string>
-    <string name="settings_12_24_timestamps">Show timestamps in 12 hour format (e.g. 2:30pm)</string>
-    <string name="settings_hide_join_leave_messages">Hide join/leave messages (invites/kicks/bans unaffected)</string>
-    <string name="settings_hide_avatar_display_name_changes_messages">Hide avatar and display name changes</string>
-    <string name="settings_disable_markdown">Disable markdown formatting when sending</string>
-    <string name="settings_vibrate_on_mention">Vibrate when mentioning</string>
+    <string name="settings_send_typing_notifs">Send typing notifications</string>
+    <string name="settings_send_markdown">Send messages with markdown formatting</string>
+    <string name="settings_always_show_timestamps">Show timestamps for all messages</string>
+    <string name="settings_12_24_timestamps">Show timestamps in twelve hour format</string>
+    <string name="settings_show_read_receipts">Show read receipts underneath messages</string>
+    <string name="settings_show_join_leave_messages">Show user join and leave messages</string>
+    <string name="settings_show_avatar_display_name_changes_messages">Show avatar and display name change messages</string>
+    <string name="settings_vibrate_on_mention">Vibrate when mentioning a user</string>
     <string name="settings_preview_media_before_sending">Preview media before sending</string>
 
     <string name="settings_deactivate_account_section">Deactivate account</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -570,13 +570,13 @@
     <string name="settings_profile_picture">Profile Picture</string>
     <string name="settings_display_name">Display Name</string>
     <string name="settings_email_address">Email</string>
-    <string name="settings_add_email_address">Add Email Address</string>
+    <string name="settings_add_email_address">Add email address</string>
     <string name="settings_phone_number">Phone</string>
-    <string name="settings_add_phone_number">Add Phone Number</string>
-    <string name="settings_app_info_link_title">Application Info</string>
+    <string name="settings_add_phone_number">Add phone number</string>
+    <string name="settings_app_info_link_title">Application info</string>
     <string name="settings_app_info_link_summary">Show the application info in the system settings.</string>
 
-    <string name="settings_notification_privacy">Notification Privacy</string>
+    <string name="settings_notification_privacy">Notification privacy</string>
     <string name="settings_notification_privacy_warning">Riot.im runs in the background to keep your notification message content private. You can change this option to reduce battery usage.</string>
     <string name="settings_notification_privacy_normal">Normal</string>
     <string name="settings_notification_privacy_power_saving">Power-saving Options</string>
@@ -590,20 +590,20 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Notifications contain <b>meta and message data</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Notifications will <b>not show message content</b></string>
 
-    <string name="settings_notification_ringtone">Notification Sound</string>
+    <string name="settings_notification_ringtone">Notification sound</string>
     <string name="settings_enable_all_notif">Enable notifications for this account</string>
     <string name="settings_enable_this_device">Enable notifications for this device</string>
     <string name="settings_turn_screen_on">Turn the screen on for 3 seconds</string>
 
-    <string name="settings_containing_my_display_name">Display Name Mentions</string>
-    <string name="settings_containing_my_user_name">User Name Mentions</string>
-    <string name="settings_messages_in_one_to_one">One-to-One Chats</string>
-    <string name="settings_messages_in_group_chat">Group Chats</string>
-    <string name="settings_invited_to_room">Room Invitations</string>
-    <string name="settings_call_invitations">Call Invitations</string>
-    <string name="settings_messages_sent_by_bot">Bot Messages</string>
+    <string name="settings_containing_my_display_name">Msgs containing my display name</string>
+    <string name="settings_containing_my_user_name">Msgs containing my user name</string>
+    <string name="settings_messages_in_one_to_one">Msgs in one-to-one chats</string>
+    <string name="settings_messages_in_group_chat">Msgs in group chats</string>
+    <string name="settings_invited_to_room">When I\'m invited to a room</string>
+    <string name="settings_call_invitations">Call invitations</string>
+    <string name="settings_messages_sent_by_bot">Messages sent by bot</string>
 
-    <string name="settings_background_sync">Background Synchronization</string>
+    <string name="settings_background_sync">Background synchronization</string>
     <string name="settings_start_on_boot">Start on boot</string>
     <string name="settings_enable_background_sync">Enable background sync</string>
     <string name="settings_set_sync_timeout">Sync request timeout</string>
@@ -617,32 +617,32 @@
     <string name="settings_third_party_notices">Third party notices</string>
     <string name="settings_copyright">Copyright</string>
     <string name="settings_privacy_policy">Privacy policy</string>
-    <string name="settings_keep_media">Keep Media</string>
-    <string name="settings_clear_cache">Clear Cache</string>
-    <string name="settings_clear_media_cache">Clear Media Cache</string>
+    <string name="settings_keep_media">Keep media</string>
+    <string name="settings_clear_cache">Clear cache</string>
+    <string name="settings_clear_media_cache">Clear media cache</string>
 
-    <string name="settings_user_settings">User Settings</string>
+    <string name="settings_user_settings">User settings</string>
     <string name="settings_notifications">Notifications</string>
     <string name="settings_ignored_users">Ignored users</string>
     <string name="settings_other">Other</string>
     <string name="settings_advanced">Advanced</string>
     <string name="settings_cryptography">Cryptography</string>
     <string name="settings_notifications_targets">Notification Targets</string>
-    <string name="settings_contact">Local Contacts</string>
+    <string name="settings_contact">Local contacts</string>
     <string name="settings_contacts_app_permission">Contacts permission</string>
-    <string name="settings_contacts_phonebook_country">Phonebook Country</string>
-    <string name="settings_home_display">Home Display</string>
+    <string name="settings_contacts_phonebook_country">Phonebook country</string>
+    <string name="settings_home_display">Home display</string>
     <string name="settings_pin_missed_notifications">Pin rooms with missed notifications</string>
     <string name="settings_pin_unread_messages">Pin rooms with unread messages</string>
     <string name="settings_devices_list">Devices</string>
-    <string name="settings_inline_url_preview">Inline URL Preview</string>
+    <string name="settings_inline_url_preview">Inline URL preview</string>
     <string name="settings_inline_url_preview_summary">Preview links within the chat when your homeserver supports this feature.</string>
-    <string name="settings_send_typing_notifs">Send Typing Notifications</string>
+    <string name="settings_send_typing_notifs">Send typing notifications</string>
     <string name="settings_send_typing_notifs_summary">Let other users know that you are typing.</string>
-    <string name="settings_send_markdown">Markdown Formatting</string>
-    <string name="settings_send_markdown_summary">Send messages with markdown when you use it for italic or bold text, among other uses.</string>
+    <string name="settings_send_markdown">Markdown formatting</string>
+    <string name="settings_send_markdown_summary">Format messages using markdown syntax before they are sent. This allows for advanced formatting such as using asterisks to display italic text.</string>
     <string name="settings_always_show_timestamps">Show timestamps for all messages</string>
-    <string name="settings_12_24_timestamps">Show timestamps in twelve hour format</string>
+    <string name="settings_12_24_timestamps">Show timestamps in 12-hour format</string>
     <string name="settings_show_read_receipts">Show read receipts</string>
     <string name="settings_show_read_receipts_summary">Click on the read receipts for a detailed list.</string>
     <string name="settings_show_join_leave_messages">Show join and leave events</string>
@@ -652,8 +652,8 @@
     <string name="settings_vibrate_on_mention">Vibrate when mentioning a user</string>
     <string name="settings_preview_media_before_sending">Preview media before sending</string>
 
-    <string name="settings_deactivate_account_section">Deactivate Account</string>
-    <string name="settings_deactivate_my_account">Deactivate Account</string>
+    <string name="settings_deactivate_account_section">Deactivate account</string>
+    <string name="settings_deactivate_my_account">Deactivate my account</string>
 
     <!-- startup -->
     <string name="startup_notification_privacy_title">Notification Privacy</string>
@@ -685,9 +685,9 @@
     <string name="settings_home_server">Home Server</string>
     <string name="settings_identity_server">Identity Server</string>
 
-    <string name="settings_user_interface">User Interface</string>
+    <string name="settings_user_interface">User interface</string>
     <string name="settings_interface_language">Language</string>
-    <string name="settings_select_language">Choose Language</string>
+    <string name="settings_select_language">Choose language</string>
 
     <string name="account_email_validation_title">Verification Pending</string>
     <string name="account_email_validation_message">Please check your email and click on the link it contains. Once this is done, click continue.</string>
@@ -697,10 +697,10 @@
     <string name="account_phone_number_already_used_error">This phone number is already in use.</string>
 
     <string name="settings_password">Password</string>
-    <string name="settings_change_password">Change Password</string>
-    <string name="settings_old_password">Old Password</string>
-    <string name="settings_new_password">New Password</string>
-    <string name="settings_confirm_password">Confirm Password</string>
+    <string name="settings_change_password">Change password</string>
+    <string name="settings_old_password">Old password</string>
+    <string name="settings_new_password">New password</string>
+    <string name="settings_confirm_password">Confirm password</string>
     <string name="settings_fail_to_update_password">Failed to update password</string>
     <string name="settings_password_updated">Your password has been updated</string>
     <string name="settings_unignore_user">Show all messages from %s?\n\nNote that this action will restart the app and it may take some time.</string>
@@ -743,7 +743,7 @@
     <string name="room_settings_tag_pref_entry_favourite">Favourite</string>
     <string name="room_settings_tag_pref_entry_low_priority">Low priority</string>
     <string name="room_settings_tag_pref_entry_none">None</string>
-    <string name="room_settings_tag_pref_no_tag">not tagged</string>
+    <string name="room_settings_tag_pref_no_tag">Not tagged</string>
 
     <!-- room settings : access and visibility -->
     <string name="room_settings_category_access_visibility_title">Access and visibility</string>
@@ -848,8 +848,8 @@
     <string name="encryption_import_room_keys_summary">Import the keys from a local file</string>
     <string name="encryption_import_import">Import</string>
     <string name="encryption_import_enter_passphrase">Enter passphrase</string>
-    <string name="encryption_never_send_to_unverified_devices_title">Only message verified devices</string>
-    <string name="encryption_never_send_to_unverified_devices_summary">If a room has encryption enabled only send messages when all devices have been verified.</string>
+    <string name="encryption_never_send_to_unverified_devices_title">Encrypt to verified devices only</string>
+    <string name="encryption_never_send_to_unverified_devices_summary">Never send encrypted messages to unverified devices from this device.</string>
 
     <string name="encryption_information_not_verified">NOT Verified</string>
     <string name="encryption_information_verified">Verified</string>
@@ -938,7 +938,7 @@
     <string name="widget_integration_invalid_parameter">A parameter is not valid.</string>
     <string name="room_add_matrix_apps">Add Matrix apps</string>
     <string name="settings_labs_native_camera">Use native camera</string>
-    <string name="settings_labs_native_camera_summary">Start the system camera instead of the custom camera activity.</string>
+    <string name="settings_labs_native_camera_summary">Start the system camera instead of the custom camera screen.</string>
     <string name="settings_labs_keyboard_options_to_send_message">Use keyboard enter key to send message</string>
     <string name="settings_labs_enable_send_voice">Send voice messages</string>
     <string name="settings_labs_enable_send_voice_summary">This option requires a third party application to record the messages.</string>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -71,12 +71,14 @@
             android:title="@string/settings_inline_url_preview" />
 
         <im.vector.preference.VectorSwitchPreference
-            android:key="SETTINGS_HIDE_READ_RECEIPTS_KEY"
-            android:title="@string/settings_hide_read_receipts" />
+            android:defaultValue="true"
+            android:key="SETTINGS_SEND_TYPING_NOTIF_KEY"
+            android:title="@string/settings_send_typing_notifs" />
 
         <im.vector.preference.VectorSwitchPreference
-            android:key="SETTINGS_DONT_SEND_TYPING_NOTIF_KEY"
-            android:title="@string/settings_dont_send_typings_notifs" />
+            android:defaultValue="true"
+            android:key="SETTINGS_SEND_MARKDOWN_KEY"
+            android:title="@string/settings_send_markdown" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY"
@@ -87,16 +89,19 @@
             android:title="@string/settings_12_24_timestamps" />
 
         <im.vector.preference.VectorSwitchPreference
-            android:key="SETTINGS_HIDE_JOIN_LEAVE_MESSAGES_KEY"
-            android:title="@string/settings_hide_join_leave_messages" />
+            android:defaultValue="true"
+            android:key="SETTINGS_SHOW_READ_RECEIPTS_KEY"
+            android:title="@string/settings_show_read_receipts" />
 
         <im.vector.preference.VectorSwitchPreference
-            android:key="SETTINGS_HIDE_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY"
-            android:title="@string/settings_hide_avatar_display_name_changes_messages" />
+            android:defaultValue="true"
+            android:key="SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY"
+            android:title="@string/settings_show_join_leave_messages" />
 
         <im.vector.preference.VectorSwitchPreference
-            android:key="SETTINGS_DISABLE_MARKDOWN_KEY"
-            android:title="@string/settings_disable_markdown" />
+            android:defaultValue="true"
+            android:key="SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY"
+            android:title="@string/settings_show_avatar_display_name_changes_messages" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_VIBRATE_ON_MENTION_KEY"

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -21,7 +21,7 @@
         <im.vector.preference.VectorCustomActionEditTextPreference
             android:key="SETTINGS_CHANGE_PASSWORD_PREFERENCE_KEY"
             android:summary="@string/password_hint"
-            android:title="@string/settings_change_password" />
+            android:title="@string/settings_password" />
 
     </PreferenceCategory>
 
@@ -68,17 +68,20 @@
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_URL_PREVIEW_KEY"
-            android:title="@string/settings_inline_url_preview" />
+            android:title="@string/settings_inline_url_preview"
+            android:summary="@string/settings_inline_url_preview_summary" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SEND_TYPING_NOTIF_KEY"
-            android:title="@string/settings_send_typing_notifs" />
+            android:title="@string/settings_send_typing_notifs"
+            android:summary="@string/settings_send_typing_notifs_summary" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SEND_MARKDOWN_KEY"
-            android:title="@string/settings_send_markdown" />
+            android:title="@string/settings_send_markdown"
+            android:summary="@string/settings_send_markdown_summary" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY"
@@ -91,17 +94,20 @@
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_READ_RECEIPTS_KEY"
-            android:title="@string/settings_show_read_receipts" />
+            android:title="@string/settings_show_read_receipts"
+            android:summary="@string/settings_show_read_receipts_summary" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY"
-            android:title="@string/settings_show_join_leave_messages" />
+            android:title="@string/settings_show_join_leave_messages"
+            android:summary="@string/settings_show_join_leave_messages_summary" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY"
-            android:title="@string/settings_show_avatar_display_name_changes_messages" />
+            android:title="@string/settings_show_avatar_display_name_changes_messages"
+            android:summary="@string/settings_show_avatar_display_name_changes_messages_summary" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_VIBRATE_ON_MENTION_KEY"
@@ -160,6 +166,11 @@
             android:key="SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY"
             android:title="@string/settings_enable_this_device" />
 
+        <im.vector.preference.VectorSwitchPreference
+            android:dependency="SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY"
+            android:key="SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY"
+            android:title="@string/settings_turn_screen_on" />
+
         <im.vector.preference.VectorCustomActionEditTextPreference
             android:dialogTitle="@string/settings_notification_privacy"
             android:key="SETTINGS_NOTIFICATION_PRIVACY_PREFERENCE_KEY"
@@ -169,11 +180,6 @@
             android:dialogTitle="@string/settings_notification_ringtone"
             android:key="SETTINGS_NOTIFICATION_RINGTONE_SELECTION_PREFERENCE_KEY"
             android:title="@string/settings_notification_ringtone" />
-
-        <im.vector.preference.VectorSwitchPreference
-            android:dependency="SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY"
-            android:key="SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY"
-            android:title="@string/settings_turn_screen_on" />
 
         <im.vector.preference.BingRulePreference
             android:dependency="SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY"
@@ -288,11 +294,13 @@
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY"
-            android:title="@string/settings_labs_native_camera" />
+            android:title="@string/settings_labs_native_camera"
+            android:summary="@string/settings_labs_native_camera_summary" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY"
-            android:title="@string/settings_labs_enable_send_voice" />
+            android:title="@string/settings_labs_enable_send_voice"
+            android:summary="@string/settings_labs_enable_send_voice_summary" />
 
     </im.vector.preference.VectorPreferenceCategory>
 
@@ -385,8 +393,8 @@
 
         <Preference
             android:key="APP_INFO_LINK_PREFERENCE_KEY"
-            android:summary="@string/settings_summary_app_info_link"
-            android:title="@string/settings_title_app_info_link" />
+            android:summary="@string/settings_app_info_link_summary"
+            android:title="@string/settings_app_info_link_title" />
 
         <im.vector.preference.VectorCustomActionEditTextPreference
             android:key="SETTINGS_VERSION_PREFERENCE_KEY"
@@ -420,7 +428,7 @@
 
         <im.vector.preference.VectorCustomActionEditTextPreference
             android:key="SETTINGS_CLEAR_MEDIA_CACHE_PREFERENCE_KEY"
-            android:title="@string/settings_clear_medias_cache" />
+            android:title="@string/settings_clear_media_cache" />
 
         <im.vector.preference.VectorCustomActionEditTextPreference
             android:key="SETTINGS_CLEAR_CACHE_PREFERENCE_KEY"

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -68,20 +68,20 @@
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_URL_PREVIEW_KEY"
-            android:title="@string/settings_inline_url_preview"
-            android:summary="@string/settings_inline_url_preview_summary" />
+            android:summary="@string/settings_inline_url_preview_summary"
+            android:title="@string/settings_inline_url_preview" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SEND_TYPING_NOTIF_KEY"
-            android:title="@string/settings_send_typing_notifs"
-            android:summary="@string/settings_send_typing_notifs_summary" />
+            android:summary="@string/settings_send_typing_notifs_summary"
+            android:title="@string/settings_send_typing_notifs" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
-            android:key="SETTINGS_SEND_MARKDOWN_KEY"
-            android:title="@string/settings_send_markdown"
-            android:summary="@string/settings_send_markdown_summary" />
+            android:key="SETTINGS_ENABLE_MARKDOWN_KEY"
+            android:summary="@string/settings_send_markdown_summary"
+            android:title="@string/settings_send_markdown" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY"
@@ -94,20 +94,20 @@
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_READ_RECEIPTS_KEY"
-            android:title="@string/settings_show_read_receipts"
-            android:summary="@string/settings_show_read_receipts_summary" />
+            android:summary="@string/settings_show_read_receipts_summary"
+            android:title="@string/settings_show_read_receipts" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY"
-            android:title="@string/settings_show_join_leave_messages"
-            android:summary="@string/settings_show_join_leave_messages_summary" />
+            android:summary="@string/settings_show_join_leave_messages_summary"
+            android:title="@string/settings_show_join_leave_messages" />
 
         <im.vector.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:key="SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY"
-            android:title="@string/settings_show_avatar_display_name_changes_messages"
-            android:summary="@string/settings_show_avatar_display_name_changes_messages_summary" />
+            android:summary="@string/settings_show_avatar_display_name_changes_messages_summary"
+            android:title="@string/settings_show_avatar_display_name_changes_messages" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_VIBRATE_ON_MENTION_KEY"
@@ -118,9 +118,9 @@
             android:title="@string/settings_preview_media_before_sending" />
 
         <ListPreference
+            android:defaultValue="always"
             android:entries="@array/show_info_area_entries"
             android:entryValues="@array/show_info_area_values"
-            android:defaultValue="always"
             android:key="SETTINGS_SHOW_INFO_AREA_KEY"
             android:summary="%s"
             android:title="@string/settings_info_area_show" />
@@ -260,7 +260,7 @@
 
     <im.vector.preference.VectorDividerCategory />
 
-    <im.vector.preference.VectorPreferenceCategory
+    <PreferenceCategory
         android:key="SETTINGS_LABS_PREFERENCE_KEY"
         android:title="@string/room_settings_labs_pref_title">
 
@@ -294,15 +294,15 @@
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_USE_NATIVE_CAMERA_PREFERENCE_KEY"
-            android:title="@string/settings_labs_native_camera"
-            android:summary="@string/settings_labs_native_camera_summary" />
+            android:summary="@string/settings_labs_native_camera_summary"
+            android:title="@string/settings_labs_native_camera" />
 
         <im.vector.preference.VectorSwitchPreference
             android:key="SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY"
-            android:title="@string/settings_labs_enable_send_voice"
-            android:summary="@string/settings_labs_enable_send_voice_summary" />
+            android:summary="@string/settings_labs_enable_send_voice_summary"
+            android:title="@string/settings_labs_enable_send_voice" />
 
-    </im.vector.preference.VectorPreferenceCategory>
+    </PreferenceCategory>
 
     <im.vector.preference.VectorDividerCategory />
 


### PR DESCRIPTION
This is related to issue #2436 and removes double negation in some of the settings. I also grouped the keys a bit more clearly in PreferencesManager and modified a couple other strings.

I tried to slim down some of the setting titles because I think it might be better in the future to explain the settings in the description and have more concise titles. One example is the inline URL previews, the title could just be `Inline URL Previews` and the description could explain that they will only be shown if your homeserver enables the feature.