### PR TITLE
display thumbnail for encrypted files without a remote thumbnail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Other changes:
 Bugfix:
  - Use same "Call Anyway" string from iOS (#2695)
  - Improve `/markdown` command (#2673)
+ - Display thumbnail for encrypted files without a remote thumbnail (#2734)
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/adapters/VectorSearchFilesListAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorSearchFilesListAdapter.java
@@ -88,6 +88,9 @@ public class VectorSearchFilesListAdapter extends VectorMessagesAdapter {
 
             if (null == thumbUrl) {
                 thumbUrl = imageMessage.getUrl();
+                encryptedFileInfo = imageMessage.file;
+            } else if (imageMessage.info != null) {
+                encryptedFileInfo = imageMessage.info.thumbnail_file;
             }
 
             if (null != imageMessage.info) {
@@ -98,10 +101,6 @@ public class VectorSearchFilesListAdapter extends VectorMessagesAdapter {
                 avatarId = R.drawable.filetype_gif;
             } else {
                 avatarId = R.drawable.filetype_image;
-            }
-
-            if (null != imageMessage.info) {
-                encryptedFileInfo = imageMessage.info.thumbnail_file;
             }
         } else if (Message.MSGTYPE_VIDEO.equals(message.msgtype)) {
             VideoMessage videoMessage = JsonUtils.toVideoMessage(event.getContent());


### PR DESCRIPTION
Now encrypted files without a thumbnail will properly show an image in the adapter.