### PR TITLE
Fix AccountCreationCaptcha error logging

### DIFF
--- a/vector/src/main/java/im/vector/activity/AccountCreationCaptchaActivity.java
+++ b/vector/src/main/java/im/vector/activity/AccountCreationCaptchaActivity.java
@@ -164,7 +164,7 @@ public class AccountCreationCaptchaActivity extends VectorAppCompatActivity {
 
             // common error message
             private void onError(String errorMessage) {
-                Log.e(LOG_TAG, "## onError() : errorMessage");
+                Log.e(LOG_TAG, "## onError() : " + errorMessage);
                 Toast.makeText(AccountCreationCaptchaActivity.this, errorMessage, Toast.LENGTH_LONG).show();
 
                 // on error case, close this activity


### PR DESCRIPTION
If a http error occured the logging did not actually report
the error message.