### PR TITLE
Propagate error messages from 3PID and display them during signup

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,3 +45,6 @@ Isa Cichon <isa4 at posteo.net>
 
 Nathan van Beelen <nathan at vanbeelen.org>
  * PR #1742: Add a media previewer
+
+Blue <blue at bluecode.fr>
+ * Propagate error messages from 3PID and display them during signup

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1141,7 +1141,7 @@ Other changes:
  -
 
 Bugfix:
- -
+ - Correct issue during signup when a 3PID error would let the signup flow spin forever
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/RegistrationManager.java
+++ b/vector/src/main/java/im/vector/RegistrationManager.java
@@ -277,8 +277,8 @@ public class RegistrationManager {
                         }
 
                         @Override
-                        public void onThreePidRequestFailed(@StringRes int errorMessageRes) {
-                            listener.onThreePidRequestFailed(context.getString(errorMessageRes));
+                        public void onThreePidRequestFailed(@StringRes int errorMessageRes, String additionalInfo) {
+                            listener.onThreePidRequestFailed(Build3PidErrorMessage(context, errorMessageRes, additionalInfo));
                         }
                     });
                     return;
@@ -862,15 +862,15 @@ public class RegistrationManager {
 
                         @Override
                         public void onUnexpectedError(Exception e) {
-                            listener.onThreePidRequested(pid);
+                            listener.onThreePidRequestFailed(R.string.account_email_error, e.toString());
                         }
 
                         @Override
                         public void onMatrixError(MatrixError e) {
                             if (TextUtils.equals(MatrixError.THREEPID_IN_USE, e.errcode)) {
-                                listener.onThreePidRequestFailed(R.string.account_email_already_used_error);
+                                listener.onThreePidRequestFailed(R.string.account_email_already_used_error, null);
                             } else {
-                                listener.onThreePidRequested(pid);
+                                listener.onThreePidRequestFailed(R.string.account_email_error, e.error);
                             }
                         }
                     });
@@ -890,21 +890,41 @@ public class RegistrationManager {
 
                         @Override
                         public void onUnexpectedError(Exception e) {
-                            listener.onThreePidRequested(pid);
+                            listener.onThreePidRequestFailed(R.string.account_email_error, e.toString());
                         }
 
                         @Override
                         public void onMatrixError(MatrixError e) {
                             if (TextUtils.equals(MatrixError.THREEPID_IN_USE, e.errcode)) {
-                                listener.onThreePidRequestFailed(R.string.account_phone_number_already_used_error);
+                                listener.onThreePidRequestFailed(R.string.account_phone_number_already_used_error, null);
                             } else {
-                                listener.onThreePidRequested(pid);
+                                listener.onThreePidRequestFailed(R.string.account_phone_number_error, e.mReason);
                             }
                         }
                     });
                     break;
             }
         }
+    }
+
+    /**
+     * Creates a 3PID error message from a string resource id and adds the additional infos, if non-null
+     * @param context
+     * @param errorMessageRes
+     * @param additionalInfo
+     * @return The error message
+     */
+    public static String Build3PidErrorMessage(Context context, @StringRes int errorMessageRes, String additionalInfo)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append(context.getString(errorMessageRes));
+
+        if (additionalInfo != null) {
+            builder.append(context.getString(R.string.account_additional_info));
+            builder.append(additionalInfo);
+        }
+
+        return builder.toString();
     }
 
     /**
@@ -1039,7 +1059,7 @@ public class RegistrationManager {
     public interface ThreePidRequestListener {
         void onThreePidRequested(ThreePid pid);
 
-        void onThreePidRequestFailed(@StringRes int errorMessageRes);
+        void onThreePidRequestFailed(@StringRes int errorMessageRes, String additionalInfo);
     }
 
     public interface ThreePidValidationListener {

--- a/vector/src/main/java/im/vector/activity/LoginActivity.java
+++ b/vector/src/main/java/im/vector/activity/LoginActivity.java
@@ -2310,7 +2310,7 @@ public class LoginActivity extends MXCActionBarActivity implements RegistrationM
             // Communicate phone number to singleton + start validation process (always phone first)
             enableLoadingScreen(true);
             mRegistrationManager
-                    .addPhoneNumberThreePid(mRegistrationPhoneNumberHandler.getE164PhoneNumber(), mRegistrationPhoneNumberHandler.getCountryCode(),
+                    .addPhoneNumberThreePid(this, mRegistrationPhoneNumberHandler.getE164PhoneNumber(), mRegistrationPhoneNumberHandler.getCountryCode(),
                             new RegistrationManager.ThreePidRequestListener() {
                                 @Override
                                 public void onThreePidRequested(ThreePid pid) {
@@ -2321,9 +2321,8 @@ public class LoginActivity extends MXCActionBarActivity implements RegistrationM
                                 }
 
                                 @Override
-                                public void onThreePidRequestFailed(@StringRes int errorMessageRes, String additionalInfo) {
-                                    String message = RegistrationManager.Build3PidErrorMessage(LoginActivity.this, errorMessageRes, additionalInfo);
-                                    LoginActivity.this.onThreePidRequestFailed(message);
+                                public void onThreePidRequestFailed(String errorMessage) {
+                                    LoginActivity.this.onThreePidRequestFailed(errorMessage);
                                 }
                             });
         } else {

--- a/vector/src/main/java/im/vector/activity/LoginActivity.java
+++ b/vector/src/main/java/im/vector/activity/LoginActivity.java
@@ -2321,8 +2321,9 @@ public class LoginActivity extends MXCActionBarActivity implements RegistrationM
                                 }
 
                                 @Override
-                                public void onThreePidRequestFailed(@StringRes int errorMessageRes) {
-                                    LoginActivity.this.onThreePidRequestFailed(getString(errorMessageRes));
+                                public void onThreePidRequestFailed(@StringRes int errorMessageRes, String additionalInfo) {
+                                    String message = RegistrationManager.Build3PidErrorMessage(LoginActivity.this, errorMessageRes, additionalInfo);
+                                    LoginActivity.this.onThreePidRequestFailed(message);
                                 }
                             });
         } else {

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -709,6 +709,7 @@
     <string name="account_email_already_used_error">This email address is already in use.</string>
     <string name="account_email_not_found_error">This email address was not found.</string>
     <string name="account_phone_number_already_used_error">This phone number is already in use.</string>
+    <string name="account_email_error">An error occurred while verifying your email address.</string>
 
     <string name="settings_password">Password</string>
     <string name="settings_change_password">Change password</string>
@@ -734,6 +735,8 @@
     <string name="settings_phone_number_verification_error_empty_code">Enter an activation code</string>
     <string name="settings_phone_number_verification_error">Error while validating your phone number</string>
     <string name="settings_phone_number_code">Code</string>
+    <string name="account_phone_number_error">An error occurred while verifying your phone number.</string>
+    <string name="account_additional_info"> Additional info : </string>
 
     <string name="settings_flair">Flair</string>
     <string name="settings_without_flair">You are not currently a member of any communities.</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -736,7 +736,7 @@
     <string name="settings_phone_number_verification_error">Error while validating your phone number</string>
     <string name="settings_phone_number_code">Code</string>
     <string name="account_phone_number_error">An error occurred while verifying your phone number.</string>
-    <string name="account_additional_info"> Additional info : </string>
+    <string name="account_additional_info">Additional info: %s</string>
 
     <string name="settings_flair">Flair</string>
     <string name="settings_without_flair">You are not currently a member of any communities.</string>


### PR DESCRIPTION
Hello ! 

This change corrects a bug where the sign-up flow hangs forever if the 3PID token request fails.

If an error occurs, the error is displayed as a Toast message and the user is taken back to the previous form.


### Pull Request Checklist

* [X] Pull request is based on the develop branch
* [X] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-android/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos if containing UI changes
* [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
