### PR TITLE
Fix devault avatar icon characters being a bit offset

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -48,3 +48,7 @@ Nathan van Beelen <nathan at vanbeelen.org>
 
 Blue <blue at bluecode.fr>
  * Propagate error messages from 3PID and display them during signup
+
+Ville Ranki <ville.ranki at iki.fi>
+ * Fix avatar icon characters being offset
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Other changes:
 Bugfix:
  - Defensive code for notifications issues + check play services as per FCM recommendation (#2266)
  - Fix many little UI/UX issues (#2769)
+ - Fix avatar icon characters being a little bit offset to right.
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/util/VectorUtils.java
+++ b/vector/src/main/java/im/vector/util/VectorUtils.java
@@ -192,7 +192,7 @@ public class VectorUtils {
      * @return the generated bitmap
      */
     private static Bitmap createAvatar(int backgroundColor, String text, int pixelsSide) {
-        android.graphics.Bitmap.Config bitmapConfig = android.graphics.Bitmap.Config.ARGB_8888;
+        Bitmap.Config bitmapConfig = Bitmap.Config.ARGB_8888;
 
         Bitmap bitmap = Bitmap.createBitmap(pixelsSide, pixelsSide, bitmapConfig);
         Canvas canvas = new Canvas(bitmap);
@@ -203,6 +203,7 @@ public class VectorUtils {
         Paint textPaint = new Paint();
         textPaint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
         textPaint.setColor(Color.WHITE);
+        textPaint.setTextAlign(Paint.Align.CENTER);
         // the text size is proportional to the avatar size.
         // by default, the avatar size is 42dp, the text size is 28 dp (not sp because it has to be fixed).
         textPaint.setTextSize(pixelsSide * 2 / 3);
@@ -213,7 +214,7 @@ public class VectorUtils {
 
         // draw the text in center
         canvas.drawText(text,
-                (canvas.getWidth() - textBounds.width() - textBounds.left) / 2,
+                canvas.getWidth() / 2,
                 (canvas.getHeight() + textBounds.height() - textBounds.bottom) / 2,
                 textPaint);
 


### PR DESCRIPTION
I noticed that there was something odd with the default avatar icons with a letter. For example letter "C" was a few pixels offset to the right, causing icons to look a bit wrong. 
This change fixes this by changing the centering code, actually simplifying it.

Signed-off-by: Ville Ranki <ville.ranki@iki.fi>
