### PR TITLE
Redact should be called 'Remove' to match riot/web

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Improvements:
  - Notification settings re-organization, added bing rule troubleshoot
  - Kotlin Code Improvement in VectorSettingsPreferencesFragment.kt
  - Remove redundant !! , Replace it with null safe operators in VectorSettingsPreferencesFragment.kt
+ - `Redact` has been renamed to `Remove` to match riot/web (#2871)
 
 
 Other changes:

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <string name="send">Send</string>
     <string name="copy">Copy</string>
     <string name="resend">Resend</string>
-    <string name="redact">Redact</string>
+    <string name="redact">Remove</string>
     <string name="quote">Quote</string>
     <string name="download">Download</string>
     <string name="share">Share</string>


### PR DESCRIPTION
Fixes #2871
