### PR TITLE
Key share request do not go away when user select "verify" (Fix #2781)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Bugfix:
  - Fix issue with registration when an email is provided (#2852)
  - Fix issues with Tombstone events (#2866 && #2867)
  - Fix crash on BugReportActivity if previous Activity is destroyed (#2876)
+ - Key share request does not go away when user select "verify" (#2781)
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/KeyRequestHandler.java
+++ b/vector/src/main/java/im/vector/KeyRequestHandler.java
@@ -278,6 +278,7 @@ public class KeyRequestHandler {
                             .setDeviceVerification(MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED, mCurrentDevice, mCurrentUser, new SimpleApiCallback<Void>() {
                                 @Override
                                 public void onSuccess(Void info) {
+                                    deviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED;
                                     displayKeyShareDialog(session, deviceInfo, true);
                                 }
                             });

--- a/vector/src/main/java/im/vector/KeyRequestHandler.java
+++ b/vector/src/main/java/im/vector/KeyRequestHandler.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 import im.vector.activity.CommonActivityUtils;
+import im.vector.listeners.YesNoListener;
 
 /**
  * Manage the key share events
@@ -346,16 +347,19 @@ public class KeyRequestHandler {
                 .setPositiveButton(R.string.start_verification,
                         new DialogInterface.OnClickListener() {
                             public void onClick(final DialogInterface dialog, int id) {
-                                CommonActivityUtils.displayDeviceVerificationDialog(deviceInfo, mCurrentUser, session, activity, new SimpleApiCallback<Void>() {
-                                    @Override
-                                    public void onSuccess(Void info) {
-                                        if (deviceInfo.isVerified()) {
-                                            onDisplayKeyShareDialogClose(true, false);
-                                        } else {
-                                            displayKeyShareDialog(session, deviceInfo, wasNewDevice);
-                                        }
-                                    }
-                                });
+                                CommonActivityUtils.displayDeviceVerificationDialog(deviceInfo, mCurrentUser, session, activity,
+                                        new YesNoListener() {
+                                            @Override
+                                            public void yes() {
+                                                onDisplayKeyShareDialogClose(true, false);
+                                            }
+
+                                            @Override
+                                            public void no() {
+                                                // Display again the same dialog
+                                                displayKeyShareDialog(session, deviceInfo, wasNewDevice);
+                                            }
+                                        });
                             }
                         })
                 .setOnCancelListener(new DialogInterface.OnCancelListener() {

--- a/vector/src/main/java/im/vector/fragments/VectorMessageListFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorMessageListFragment.java
@@ -86,6 +86,7 @@ import im.vector.adapters.VectorMessagesAdapter;
 import im.vector.db.VectorContentProvider;
 import im.vector.extensions.MatrixSdkExtensionsKt;
 import im.vector.listeners.IMessagesAdapterActionsListener;
+import im.vector.listeners.YesNoListener;
 import im.vector.receiver.VectorUniversalLinkReceiver;
 import im.vector.ui.themes.ThemeUtils;
 import im.vector.util.ExternalApplicationsUtilKt;
@@ -375,6 +376,18 @@ public class VectorMessageListFragment extends MatrixMessageListFragment<VectorM
         }
     };
 
+    private final YesNoListener mYesNoListener = new YesNoListener() {
+        @Override
+        public void yes() {
+            mAdapter.notifyDataSetChanged();
+        }
+
+        @Override
+        public void no() {
+            mAdapter.notifyDataSetChanged();
+        }
+    };
+
     /**
      * the user taps on the e2e icon
      *
@@ -473,7 +486,7 @@ public class VectorMessageListFragment extends MatrixMessageListFragment<VectorM
                     builder.setNegativeButton(R.string.encryption_information_verify, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int id) {
                             CommonActivityUtils.displayDeviceVerificationDialog(deviceInfo,
-                                    event.getSender(), mSession, getActivity(), mDeviceVerificationCallback);
+                                    event.getSender(), mSession, getActivity(), mYesNoListener);
                         }
                     });
 
@@ -501,7 +514,7 @@ public class VectorMessageListFragment extends MatrixMessageListFragment<VectorM
                     builder.setNegativeButton(R.string.encryption_information_verify, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int id) {
                             CommonActivityUtils.displayDeviceVerificationDialog(deviceInfo,
-                                    event.getSender(), mSession, getActivity(), mDeviceVerificationCallback);
+                                    event.getSender(), mSession, getActivity(), mYesNoListener);
                         }
                     });
 

--- a/vector/src/main/java/im/vector/fragments/VectorUnknownDevicesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorUnknownDevicesFragment.java
@@ -40,6 +40,7 @@ import im.vector.Matrix;
 import im.vector.R;
 import im.vector.activity.CommonActivityUtils;
 import im.vector.adapters.VectorUnknownDevicesAdapter;
+import im.vector.listeners.YesNoListener;
 
 public class VectorUnknownDevicesFragment extends DialogFragment {
     private static final String ARG_SESSION_ID = "VectorUnknownDevicesFragment.ARG_SESSION_ID";
@@ -169,6 +170,18 @@ public class VectorUnknownDevicesFragment extends DialogFragment {
                 }
             };
 
+            final YesNoListener yesNoListener = new YesNoListener() {
+                @Override
+                public void yes() {
+                    refresh();
+                }
+
+                @Override
+                public void no() {
+                    refresh();
+                }
+            };
+
             @Override
             public void OnVerifyDeviceClick(MXDeviceInfo aDeviceInfo) {
                 switch (aDeviceInfo.mVerified) {
@@ -179,7 +192,7 @@ public class VectorUnknownDevicesFragment extends DialogFragment {
 
                     case MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED:
                     default: // Blocked
-                        CommonActivityUtils.displayDeviceVerificationDialog(aDeviceInfo, aDeviceInfo.userId, mSession, getActivity(), mCallback);
+                        CommonActivityUtils.displayDeviceVerificationDialog(aDeviceInfo, aDeviceInfo.userId, mSession, getActivity(), yesNoListener);
                         break;
                 }
             }

--- a/vector/src/main/java/im/vector/fragments/VectorUnknownDevicesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorUnknownDevicesFragment.java
@@ -151,29 +151,36 @@ public class VectorUnknownDevicesFragment extends DialogFragment {
                 switch (aDeviceInfo.mVerified) {
                     case MXDeviceInfo.DEVICE_VERIFICATION_VERIFIED:
                         mSession.getCrypto()
-                                .setDeviceVerification(MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED, aDeviceInfo.deviceId, aDeviceInfo.userId, new SimpleApiCallback<Void>() {
-                                    @Override
-                                    public void onSuccess(Void info) {
-                                        aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED;
-                                        refresh();
-                                    }
-                                });
+                                .setDeviceVerification(MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED,
+                                        aDeviceInfo.deviceId,
+                                        aDeviceInfo.userId,
+                                        new SimpleApiCallback<Void>() {
+                                            @Override
+                                            public void onSuccess(Void info) {
+                                                aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED;
+                                                refresh();
+                                            }
+                                        });
                         break;
 
                     case MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED:
                     default: // Blocked
-                        CommonActivityUtils.displayDeviceVerificationDialog(aDeviceInfo, aDeviceInfo.userId, mSession, getActivity(), new YesNoListener() {
-                            @Override
-                            public void yes() {
-                                aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_VERIFIED;
-                                refresh();
-                            }
+                        CommonActivityUtils.displayDeviceVerificationDialog(aDeviceInfo,
+                                aDeviceInfo.userId,
+                                mSession,
+                                getActivity(),
+                                new YesNoListener() {
+                                    @Override
+                                    public void yes() {
+                                        aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_VERIFIED;
+                                        refresh();
+                                    }
 
-                            @Override
-                            public void no() {
-                                // Nothing to do
-                            }
-                        });
+                                    @Override
+                                    public void no() {
+                                        // Nothing to do
+                                    }
+                                });
                         break;
                 }
             }
@@ -182,22 +189,28 @@ public class VectorUnknownDevicesFragment extends DialogFragment {
             public void OnBlockDeviceClick(MXDeviceInfo aDeviceInfo) {
                 if (aDeviceInfo.mVerified == MXDeviceInfo.DEVICE_VERIFICATION_BLOCKED) {
                     mSession.getCrypto()
-                            .setDeviceVerification(MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED, aDeviceInfo.deviceId, aDeviceInfo.userId, new SimpleApiCallback<Void>() {
-                                @Override
-                                public void onSuccess(Void info) {
-                                    aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED;
-                                    refresh();
-                                }
-                            });
+                            .setDeviceVerification(MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED,
+                                    aDeviceInfo.deviceId,
+                                    aDeviceInfo.userId,
+                                    new SimpleApiCallback<Void>() {
+                                        @Override
+                                        public void onSuccess(Void info) {
+                                            aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_UNVERIFIED;
+                                            refresh();
+                                        }
+                                    });
                 } else {
                     mSession.getCrypto()
-                            .setDeviceVerification(MXDeviceInfo.DEVICE_VERIFICATION_BLOCKED, aDeviceInfo.deviceId, aDeviceInfo.userId, new SimpleApiCallback<Void>() {
-                                @Override
-                                public void onSuccess(Void info) {
-                                    aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_BLOCKED;
-                                    refresh();
-                                }
-                            });
+                            .setDeviceVerification(MXDeviceInfo.DEVICE_VERIFICATION_BLOCKED,
+                                    aDeviceInfo.deviceId,
+                                    aDeviceInfo.userId,
+                                    new SimpleApiCallback<Void>() {
+                                        @Override
+                                        public void onSuccess(Void info) {
+                                            aDeviceInfo.mVerified = MXDeviceInfo.DEVICE_VERIFICATION_BLOCKED;
+                                            refresh();
+                                        }
+                                    });
                 }
             }
         });

--- a/vector/src/main/java/im/vector/listeners/YesNoListener.kt
+++ b/vector/src/main/java/im/vector/listeners/YesNoListener.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.listeners
+
+/**
+ * Simple interface with yes() and no() methods
+ */
+interface YesNoListener {
+    fun yes()
+
+    fun no()
+}


### PR DESCRIPTION
deviceInfo.isVerified() is not usable as this since we now store data in Realm

Database was well updated with the verified status, but the dialog was displayed again by mistake.