### PR TITLE
Fix warning "Attribute value must be constant"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Other changes:
  -
 
 Bugfix:
- -
+ - Fix warning "Attribute value must be constant" in VectorHomeActivity
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -208,7 +208,7 @@ public class VectorHomeActivity extends VectorAppCompatActivity implements Searc
     @BindView(R.id.floating_action_menu)
     FloatingActionsMenu mFloatingActionsMenu;
 
-    @BindView(com.getbase.floatingactionbutton.R.id.fab_expand_menu_button)
+    @BindView(R.id.fab_expand_menu_button)
     AddFloatingActionButton mFabMain;
 
     @BindView(R.id.button_start_chat)


### PR DESCRIPTION
- Id starts with "R.id." as described in @BindView docs

Signed-off-by: Marco Festini <marco.festini@awesome-technologies.de>