### PR TITLE
Show direct chat section in user details only for other users, not self

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Improvements:
  - keys backup: Setup screen UX improvement
  - keys backup: Sign Out flow improvement
  - Improved button styles (states, ripple effect)
+ - Show direct chat section in user details only for other users, not self
 
 Other changes:
  -

--- a/vector/src/main/java/im/vector/activity/VectorMemberDetailsActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorMemberDetailsActivity.java
@@ -1125,21 +1125,22 @@ public class VectorMemberDetailsActivity extends MXCActionBarActivity implements
             }
 
             // direct chats management
-
-            // list other direct rooms
-            List<String> roomIds = mSession.getDataHandler().getDirectChatRoomIdsList(mMemberId);
-            for (String roomId : roomIds) {
-                Room room = mSession.getDataHandler().getRoom(roomId);
-                if (null != room) {
-                    directMessagesActions.add(new VectorMemberDetailsAdapter.AdapterMemberActionItems(room));
+            if (mMemberId != null && mSession != null && !mMemberId.equals(mSession.getMyUserId())) {
+                // list other direct rooms
+                List<String> roomIds = mSession.getDataHandler().getDirectChatRoomIdsList(mMemberId);
+                for (String roomId : roomIds) {
+                    Room room = mSession.getDataHandler().getRoom(roomId);
+                    if (null != room) {
+                        directMessagesActions.add(new VectorMemberDetailsAdapter.AdapterMemberActionItems(room));
+                    }
                 }
+
+                imageResource = R.drawable.ic_add_black;
+                actionText = getString(R.string.start_new_chat);
+                directMessagesActions.add(new VectorMemberDetailsAdapter.AdapterMemberActionItems(imageResource, actionText, ITEM_ACTION_START_CHAT));
+
+                mListViewAdapter.setDirectCallsActionsList(directMessagesActions);
             }
-
-            imageResource = R.drawable.ic_add_black;
-            actionText = getString(R.string.start_new_chat);
-            directMessagesActions.add(new VectorMemberDetailsAdapter.AdapterMemberActionItems(imageResource, actionText, ITEM_ACTION_START_CHAT));
-
-            mListViewAdapter.setDirectCallsActionsList(directMessagesActions);
             mListViewAdapter.notifyDataSetChanged();
 
             mExpandableListView.post(new Runnable() {


### PR DESCRIPTION
Since directs chats with myself don't make much sense, I thought it's a reasonable change to not show this section in the user details activity.

![screenshot_1550499080](https://user-images.githubusercontent.com/44062083/52957651-756f9700-3392-11e9-8996-ee8c9a096805.png)
