### PR TITLE
Remove trailing dot from app title

### DIFF
--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1235,7 +1235,7 @@
     <string name="no_valid_google_play_services_apk">No valid Google Play Services APK found. Notifications may not work properly.</string>
 
     <!-- String for Play Store -->
-    <string name="store_title">Riot.im - Communicate, your way.</string>
+    <string name="store_title">Riot.im - Communicate, your way</string>
     <string name="store_whats_new">"We’re always making changes and improvements to Riot.im.
 The complete changelog can be found here: %1$s.
 To make sure you don’t miss a thing, just keep your updates turned on."</string>


### PR DESCRIPTION
It's awkward for an App store application title to end with a full stop.

Signed-off-by: Jordi Mallach <jordi@mallach.net>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riot-android/CONTRIBUTING.md) before submitting your pull request -->

* [ ] Changes has been tested on an Android device or Android emulator with API 16
* [ ] UI change has been tested on both light and dark themes
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-android/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos if containing UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
