### PR TITLE
Fix / crash when session store is null in event stream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Other changes:
  -
 
 Bugfix:
- -
+ - Fix / Logged out and crashed (rageshake) #5159
 
 Translations:
  -

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Other changes:
  -
 
 Bugfix:
- - Fix / Logged out and crashed (rageshake) #5159
+ - Fix / Crash when session store is null in event stream #3158
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -142,7 +142,7 @@ public class Matrix {
             if ((null != instance) && (null != instance.mMXSessions)) {
                 if (mClearCacheRequired && !VectorApp.isAppInBackground()) {
                     mClearCacheRequired = false;
-                    instance.reloadSessions(VectorApp.getInstance());
+                    instance.reloadSessions(VectorApp.getInstance(), true);
                 } else if (mRefreshUnreadCounter) {
                     PushManager pushManager = instance.getPushManager();
 
@@ -803,9 +803,10 @@ public class Matrix {
      * The session caches are cleared before being reloaded.
      * Any opened activity is closed and the application switches to the splash screen.
      *
-     * @param context the context
+     * @param context        the context
+     * @param launchActivity
      */
-    public void reloadSessions(final Context context) {
+    public void reloadSessions(final Context context, boolean launchActivity) {
         Log.e(LOG_TAG, "## reloadSessions");
 
         CommonActivityUtils.logout(context, getMXSessions(context), false, new SimpleApiCallback<Void>() {
@@ -825,18 +826,21 @@ public class Matrix {
                 Matrix.getInstance(context).getPushManager().clearFcmData(new SimpleApiCallback<Void>() {
                     @Override
                     public void onSuccess(final Void anything) {
-                        Intent intent = new Intent(context.getApplicationContext(), SplashActivity.class);
-                        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                        context.getApplicationContext().startActivity(intent);
+                        if (launchActivity) {
+                            Intent intent = new Intent(context.getApplicationContext(), SplashActivity.class);
+                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                            context.getApplicationContext().startActivity(intent);
+                        }
 
                         if (null != VectorApp.getCurrentActivity()) {
                             VectorApp.getCurrentActivity().finish();
 
-                            if (context instanceof SplashActivity) {
-                                // Avoid bad visual effect, due to check of lazy loading status
-                                ((SplashActivity) context).overridePendingTransition(0, 0);
+                            if (launchActivity) {
+                                if (context instanceof SplashActivity) {
+                                    // Avoid bad visual effect, due to check of lazy loading status
+                                    ((SplashActivity) context).overridePendingTransition(0, 0);
+                                }
                             }
-
                         }
                     }
                 });

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -1121,7 +1121,7 @@ public class CommonActivityUtils {
                     CommonActivityUtils.restartApp(activity);
                 } else {
                     Log.e(LOW_MEMORY_LOG_TAG, "clear the application cache");
-                    Matrix.getInstance(activity).reloadSessions(activity);
+                    Matrix.getInstance(activity).reloadSessions(activity, true);
                 }
             } else {
                 Log.e(LOW_MEMORY_LOG_TAG, "Wait to be concerned");

--- a/vector/src/main/java/im/vector/activity/SplashActivity.java
+++ b/vector/src/main/java/im/vector/activity/SplashActivity.java
@@ -162,7 +162,7 @@ public class SplashActivity extends MXCActionBarActivity {
                     .apply();
 
             // Force a clear cache
-            Matrix.getInstance(this).reloadSessions(this);
+            Matrix.getInstance(this).reloadSessions(this, true);
             return;
         }
 
@@ -221,7 +221,7 @@ public class SplashActivity extends MXCActionBarActivity {
                             PreferencesManager.setUseLazyLoading(SplashActivity.this, true);
 
                             // Reload the sessions
-                            Matrix.getInstance(SplashActivity.this).reloadSessions(SplashActivity.this);
+                            Matrix.getInstance(SplashActivity.this).reloadSessions(SplashActivity.this, true);
                         } else {
                             // Maybe in the future this home server will support it
                             startEventStreamService(sessions);

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
@@ -566,7 +566,7 @@ class VectorSettingsPreferencesFragment : PreferenceFragmentCompat(), SharedPref
             if (!bNewValue) {
                 // Disable LazyLoading, just reload the sessions
                 PreferencesManager.setUserRefuseLazyLoading(appContext)
-                Matrix.getInstance(appContext).reloadSessions(appContext)
+                Matrix.getInstance(appContext).reloadSessions(appContext, true)
             } else {
                 // Try to enable LazyLoading
                 displayLoadingView()
@@ -578,7 +578,7 @@ class VectorSettingsPreferencesFragment : PreferenceFragmentCompat(), SharedPref
                             PreferencesManager.setUseLazyLoading(activity, true)
 
                             // Reload the sessions
-                            Matrix.getInstance(appContext).reloadSessions(appContext)
+                            Matrix.getInstance(appContext).reloadSessions(appContext, true)
                         } else {
                             // The server does not support lazy loading yet
                             hideLoadingView()
@@ -816,7 +816,7 @@ class VectorSettingsPreferencesFragment : PreferenceFragmentCompat(), SharedPref
 
             it.onPreferenceClickListener = Preference.OnPreferenceClickListener {
                 displayLoadingView()
-                Matrix.getInstance(appContext).reloadSessions(appContext)
+                Matrix.getInstance(appContext).reloadSessions(appContext, true)
                 false
             }
         }

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -604,7 +604,7 @@ public class EventStreamService extends Service {
                         startEventStream(session, store);
                     } else {
                         // the data are out of sync
-                        Matrix.getInstance(getApplicationContext()).reloadSessions(getApplicationContext());
+                        Matrix.getInstance(getApplicationContext()).reloadSessions(getApplicationContext(), true);
                     }
                 }
 
@@ -614,7 +614,7 @@ public class EventStreamService extends Service {
 
                     uiHandler.post(() -> {
                         Toast.makeText(getApplicationContext(), accountId + " : " + description, Toast.LENGTH_LONG).show();
-                        Matrix.getInstance(getApplicationContext()).reloadSessions(getApplicationContext());
+                        Matrix.getInstance(getApplicationContext()).reloadSessions(getApplicationContext(), true);
                     });
                 }
             });
@@ -659,7 +659,7 @@ public class EventStreamService extends Service {
 
         for (final MXSession session : mSessions) {
             // session == null has been reported by GA
-            if ((null == session) || (null == session.getDataHandler()) || (null == session.getDataHandler().getStore())) {
+            if ((null == session)) {
                 Log.i(LOG_TAG, "start : the session is not anymore valid.");
                 return;
             }

--- a/vector/src/main/java/im/vector/services/EventStreamServiceX.kt
+++ b/vector/src/main/java/im/vector/services/EventStreamServiceX.kt
@@ -190,6 +190,14 @@ class EventStreamServiceX : VectorService() {
             return START_NOT_STICKY
         }
 
+        if (mSession?.dataHandler == null || mSession?.dataHandler?.store == null) {
+            Log.e(LOG_TAG, "onStartCommand : invalid session")
+            //this might launch riot?
+            Matrix.getInstance(applicationContext)?.reloadSessions(applicationContext, false)
+            myStopSelf()
+            return START_NOT_STICKY
+        }
+
         when (action) {
             ACTION_START,
             ACTION_GO_TO_FOREGROUND ->
@@ -319,7 +327,7 @@ class EventStreamServiceX : VectorService() {
                         startEventStream(session, store)
                     } else {
                         // the data are out of sync
-                        Matrix.getInstance(applicationContext)!!.reloadSessions(applicationContext)
+                        Matrix.getInstance(applicationContext)!!.reloadSessions(applicationContext, true)
                     }
 
                     store.removeMXStoreListener(this)
@@ -330,7 +338,7 @@ class EventStreamServiceX : VectorService() {
 
                     uiHandler.post {
                         Toast.makeText(applicationContext, "$accountId : $description", Toast.LENGTH_LONG).show()
-                        Matrix.getInstance(applicationContext)!!.reloadSessions(applicationContext)
+                        Matrix.getInstance(applicationContext)!!.reloadSessions(applicationContext, true)
                     }
                 }
             })


### PR DESCRIPTION
Fixes #3158
Ignore the start command, and reload sessions
-> Rageshake 5159
-> Reported on gplay console (8 crashes / 6 users)