### PR TITLE
include 64bits version of the libraries in the APK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Translations:
  -
 
 Build:
- -
+ - Include native libraries for 64 bits processors.
 
 
 Changes in Riot 0.9.2 (2019-07-18)

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -44,16 +44,7 @@ android {
         versionName rootProject.ext.versionNameProp
 
         ndk {
-            abiFilters "armeabi-v7a", "x86"
-        }
-
-        packagingOptions {
-            // The project react-native does not provide 64-bit binaries at the
-            // time of this writing. Unfortunately, packaging any 64-bit
-            // binaries into the .apk will crash the app at runtime on 64-bit
-            // platforms.
-            exclude "lib/x86_64/libjingle_peerconnection_so.so"
-            exclude "lib/arm64-v8a/libjingle_peerconnection_so.so"
+            abiFilters "armeabi-v7a", "x86", 'arm64-v8a', 'x86_64'
         }
 
         multiDexEnabled true


### PR DESCRIPTION
Here are the included libraries in the APK:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/3940906/61526041-ec7c8a80-aa19-11e9-9382-aad7808d50f1.png">

Note that the APK size is growing up due to this change (about +40%), but we do not want to let Google sign the APK for us.

Tested ok by only selecting ```abiFilters 'arm64-v8a'``` on Samsung GS9 running API 28