### PR TITLE
make Widget/Integration mgr optional (#3224)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ MatrixSdk:
  - Changelog: https://github.com/matrix-org/matrix-android-sdk/releases/tag/v0.XX
 
 Features:
- -
+ - Make Widget/Integration Manager optional (#3224)
 
 Improvements:
  -

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -2,6 +2,7 @@
  * Copyright 2016 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
  * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +75,7 @@ import im.vector.store.LoginStorage;
 import im.vector.tools.VectorUncaughtExceptionHandler;
 import im.vector.ui.badge.BadgeProxy;
 import im.vector.util.PreferencesManager;
+import im.vector.widgets.WidgetManagerProvider;
 import im.vector.widgets.WidgetsManager;
 
 /**
@@ -131,7 +133,10 @@ public class Matrix {
             mRefreshUnreadCounter |= Event.EVENT_TYPE_MESSAGE.equals(event.getType()) || Event.EVENT_TYPE_RECEIPT.equals(event.getType());
 
             // TODO update to manage multisessions
-            WidgetsManager.getSharedInstance().onLiveEvent(instance.getDefaultSession(), event);
+            WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(VectorApp.getInstance().getApplicationContext());
+            if (wm != null) {
+                wm.onLiveEvent(instance.getDefaultSession(), event);
+            }
         }
 
         @Override

--- a/vector/src/main/java/im/vector/activity/AbstractWidgetActivity.kt
+++ b/vector/src/main/java/im/vector/activity/AbstractWidgetActivity.kt
@@ -34,6 +34,7 @@ import im.vector.types.JsonDict
 import im.vector.types.WidgetEventData
 import im.vector.util.AssetReader
 import im.vector.util.toJsonMap
+import im.vector.widgets.WidgetManagerProvider
 import im.vector.widgets.WidgetsManager
 import org.matrix.androidsdk.MXSession
 import org.matrix.androidsdk.core.JsonUtils
@@ -76,6 +77,7 @@ abstract class AbstractWidgetActivity : VectorAppCompatActivity() {
     private var mHistoryAlreadyCleared = false
 
 
+    lateinit var widgetManager : WidgetsManager
     /* ==========================================================================================
      * LIFE CYCLE
      * ========================================================================================== */
@@ -94,6 +96,11 @@ abstract class AbstractWidgetActivity : VectorAppCompatActivity() {
 
         mRoom = mSession!!.dataHandler.getRoom(intent.getStringExtra(EXTRA_ROOM_ID))
 
+        widgetManager = WidgetManagerProvider.getWidgetManager(this) ?: run {
+            finish()
+            return
+        }
+
         getScalarTokenAndLoadUrl()
     }
 
@@ -101,7 +108,7 @@ abstract class AbstractWidgetActivity : VectorAppCompatActivity() {
         if (canScalarTokenBeProvided()) {
             showWaitingView()
 
-            WidgetsManager.getScalarToken(this, mSession!!, object : ApiCallback<String> {
+            widgetManager.getScalarToken(this, mSession!!, object : ApiCallback<String> {
                 override fun onSuccess(scalarToken: String) {
                     mIsRefreshingToken = false
                     hideWaitingView()
@@ -205,7 +212,7 @@ abstract class AbstractWidgetActivity : VectorAppCompatActivity() {
                             && !mTokenAlreadyRefreshed) {
                         mTokenAlreadyRefreshed = true
                         mIsRefreshingToken = true
-                        WidgetsManager.clearScalarToken(this@AbstractWidgetActivity, mSession)
+                        widgetManager.clearScalarToken(this@AbstractWidgetActivity, mSession)
 
                         // Hide the webview because it's displaying an error message we try to fix by refreshing the token
                         mWebView.isVisible = false

--- a/vector/src/main/java/im/vector/activity/IntegrationManagerActivity.kt
+++ b/vector/src/main/java/im/vector/activity/IntegrationManagerActivity.kt
@@ -74,7 +74,7 @@ class IntegrationManagerActivity : AbstractWidgetActivity() {
      */
     override fun buildInterfaceUrl(scalarToken: String?): String? {
         try {
-            return StringBuilder(getString(R.string.integrations_ui_url))
+            return StringBuilder(widgetManager.uiUrl)
                     .apply {
                         scalarToken?.let {
                             appendParamToUrl("scalar_token", it)
@@ -259,7 +259,7 @@ class IntegrationManagerActivity : AbstractWidgetActivity() {
 
         Log.d(LOG_TAG, "Received request to get widget in room " + mRoom!!.roomId)
 
-        val widgets = WidgetsManager.getSharedInstance().getActiveWidgets(mSession, mRoom)
+        val widgets = widgetManager.getActiveWidgets(mSession, mRoom)
         val responseData = ArrayList<JsonDict<Any>>()
 
         for (widget in widgets) {

--- a/vector/src/main/java/im/vector/activity/JitsiCallActivity.java
+++ b/vector/src/main/java/im/vector/activity/JitsiCallActivity.java
@@ -42,6 +42,7 @@ import butterknife.BindView;
 import im.vector.Matrix;
 import im.vector.R;
 import im.vector.widgets.Widget;
+import im.vector.widgets.WidgetManagerProvider;
 import im.vector.widgets.WidgetsManager;
 
 /**
@@ -232,7 +233,10 @@ public class JitsiCallActivity extends VectorAppCompatActivity implements JitsiM
     protected void onStop() {
         super.onStop();
         JitsiMeetActivityDelegate.onHostPause(this);
-        WidgetsManager.removeListener(mWidgetListener);
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(this);
+        if (wm != null) {
+            wm.removeListener(mWidgetListener);
+        }
     }
 
     @Override
@@ -245,7 +249,10 @@ public class JitsiCallActivity extends VectorAppCompatActivity implements JitsiM
         super.onResume();
 
         JitsiMeetActivityDelegate.onHostResume(this);
-        WidgetsManager.addListener(mWidgetListener);
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(this);
+        if (wm != null) {
+            wm.addListener(mWidgetListener);
+        }
     }
 
     @Override

--- a/vector/src/main/java/im/vector/activity/JitsiCallActivity.java
+++ b/vector/src/main/java/im/vector/activity/JitsiCallActivity.java
@@ -109,6 +109,10 @@ public class JitsiCallActivity extends VectorAppCompatActivity implements JitsiM
     @Override
     @SuppressLint("NewApi")
     public void initUiAndData() {
+        if (WidgetManagerProvider.INSTANCE.getWidgetManager(this) == null) {
+            finish();
+            return;
+        }
         // Waiting View
         setWaitingView(findViewById(R.id.jitsi_progress_layout));
 

--- a/vector/src/main/java/im/vector/activity/StickerPickerActivity.kt
+++ b/vector/src/main/java/im/vector/activity/StickerPickerActivity.kt
@@ -55,7 +55,7 @@ class StickerPickerActivity : AbstractWidgetActivity() {
     }
 
     override fun canScalarTokenBeProvided(): Boolean {
-        return WidgetsManager.isScalarUrl(this, mWidgetUrl)
+        return widgetManager.isScalarUrl(this, mWidgetUrl)
     }
 
     /**

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -3993,6 +3993,13 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
                     .setIcon(android.R.drawable.ic_dialog_alert)
                     .setPositiveButton(R.string.ok, null)
                     .show();
+        } else if (WidgetManagerProvider.INSTANCE.getWidgetManager(this) == null) {
+            // display the dialog with the info text
+            new AlertDialog.Builder(this)
+                    .setMessage(R.string.widget_integration_no_server)
+                    .setIcon(android.R.drawable.ic_dialog_alert)
+                    .setPositiveButton(R.string.ok, null)
+                    .show();
         } else if (isUserAllowedToStartConfCall()) {
             if (mRoom.getNumberOfMembers() > 2) {
                 new AlertDialog.Builder(this)

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -2,6 +2,7 @@
  * Copyright 2015 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
  * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +135,7 @@ import im.vector.view.VectorAutoCompleteTextView;
 import im.vector.view.VectorOngoingConferenceCallView;
 import im.vector.view.VectorPendingCallView;
 import im.vector.widgets.Widget;
+import im.vector.widgets.WidgetManagerProvider;
 import im.vector.widgets.WidgetsManager;
 
 /**
@@ -860,34 +862,37 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
                         .setPositiveButton(R.string.remove, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                showWaitingView();
+                                WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(VectorRoomActivity.this);
+                                if (wm != null) {
+                                    showWaitingView();
 
-                                WidgetsManager.getSharedInstance().closeWidget(mSession, mRoom, widget.getWidgetId(), new ApiCallback<Void>() {
-                                    @Override
-                                    public void onSuccess(Void info) {
-                                        hideWaitingView();
-                                    }
+                                    wm.closeWidget(mSession, mRoom, widget.getWidgetId(), new ApiCallback<Void>() {
+                                        @Override
+                                        public void onSuccess(Void info) {
+                                            hideWaitingView();
+                                        }
 
-                                    private void onError(String errorMessage) {
-                                        hideWaitingView();
-                                        Toast.makeText(VectorRoomActivity.this, errorMessage, Toast.LENGTH_SHORT).show();
-                                    }
+                                        private void onError(String errorMessage) {
+                                            hideWaitingView();
+                                            Toast.makeText(VectorRoomActivity.this, errorMessage, Toast.LENGTH_SHORT).show();
+                                        }
 
-                                    @Override
-                                    public void onNetworkError(Exception e) {
-                                        onError(e.getLocalizedMessage());
-                                    }
+                                        @Override
+                                        public void onNetworkError(Exception e) {
+                                            onError(e.getLocalizedMessage());
+                                        }
 
-                                    @Override
-                                    public void onMatrixError(MatrixError e) {
-                                        onError(e.getLocalizedMessage());
-                                    }
+                                        @Override
+                                        public void onMatrixError(MatrixError e) {
+                                            onError(e.getLocalizedMessage());
+                                        }
 
-                                    @Override
-                                    public void onUnexpectedError(Exception e) {
-                                        onError(e.getLocalizedMessage());
-                                    }
-                                });
+                                        @Override
+                                        public void onUnexpectedError(Exception e) {
+                                            onError(e.getLocalizedMessage());
+                                        }
+                                    });
+                                }
                             }
                         })
                         .setNegativeButton(R.string.cancel, null)
@@ -962,34 +967,37 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
 
             @Override
             public void onCloseWidgetClick(Widget widget) {
-                showWaitingView();
+                WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(VectorRoomActivity.this);
+                if (wm != null) {
+                    showWaitingView();
 
-                WidgetsManager.getSharedInstance().closeWidget(mSession, mRoom, widget.getWidgetId(), new ApiCallback<Void>() {
-                    @Override
-                    public void onSuccess(Void info) {
-                        hideWaitingView();
-                    }
+                    wm.closeWidget(mSession, mRoom, widget.getWidgetId(), new ApiCallback<Void>() {
+                        @Override
+                        public void onSuccess(Void info) {
+                            hideWaitingView();
+                        }
 
-                    private void onError(String errorMessage) {
-                        hideWaitingView();
-                        Toast.makeText(VectorRoomActivity.this, errorMessage, Toast.LENGTH_SHORT).show();
-                    }
+                        private void onError(String errorMessage) {
+                            hideWaitingView();
+                            Toast.makeText(VectorRoomActivity.this, errorMessage, Toast.LENGTH_SHORT).show();
+                        }
 
-                    @Override
-                    public void onNetworkError(Exception e) {
-                        onError(e.getLocalizedMessage());
-                    }
+                        @Override
+                        public void onNetworkError(Exception e) {
+                            onError(e.getLocalizedMessage());
+                        }
 
-                    @Override
-                    public void onMatrixError(MatrixError e) {
-                        onError(e.getLocalizedMessage());
-                    }
+                        @Override
+                        public void onMatrixError(MatrixError e) {
+                            onError(e.getLocalizedMessage());
+                        }
 
-                    @Override
-                    public void onUnexpectedError(Exception e) {
-                        onError(e.getLocalizedMessage());
-                    }
-                });
+                        @Override
+                        public void onUnexpectedError(Exception e) {
+                            onError(e.getLocalizedMessage());
+                        }
+                    });
+                }
             }
 
             @Override
@@ -1483,6 +1491,8 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
             return true;
         }
 
+        boolean hasIntegrationManager = WidgetManagerProvider.INSTANCE.getWidgetManager(this) != null;
+
         // the menu is only displayed when the current activity does not display a timeline search
         if (TextUtils.isEmpty(mEventId) && (null == sRoomPreviewData)) {
             RoomMember member = mRoom.getMember(mSession.getMyUserId());
@@ -1492,7 +1502,7 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
                 searchInRoomMenuItem.setVisible(!mRoom.isEncrypted());
             }
             if (useMatrixAppsMenuItem != null) {
-                useMatrixAppsMenuItem.setVisible(TextUtils.isEmpty(mEventId) && null == sRoomPreviewData);
+                useMatrixAppsMenuItem.setVisible(hasIntegrationManager && TextUtils.isEmpty(mEventId) && null == sRoomPreviewData);
             }
             if (resendUnsentMenuItem != null) {
                 resendUnsentMenuItem.setVisible(mHasUnsentEvents);
@@ -1761,37 +1771,40 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
      * @param aIsVideoCall true if the call is a video one
      */
     private void startJitsiCall(final boolean aIsVideoCall) {
-        enableActionBarHeader(HIDE_ACTION_BAR_HEADER);
-        showWaitingView();
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(this);
+        if (wm != null) {
+            enableActionBarHeader(HIDE_ACTION_BAR_HEADER);
+            showWaitingView();
 
-        WidgetsManager.getSharedInstance().createJitsiWidget(mSession, mRoom, aIsVideoCall, new ApiCallback<Widget>() {
-            @Override
-            public void onSuccess(Widget widget) {
-                hideWaitingView();
+            wm.createJitsiWidget(mSession, mRoom, aIsVideoCall, new ApiCallback<Widget>() {
+                @Override
+                public void onSuccess(Widget widget) {
+                    hideWaitingView();
 
-                launchJitsiActivity(widget, aIsVideoCall);
-            }
+                    launchJitsiActivity(widget, aIsVideoCall);
+                }
 
-            private void onError(String errorMessage) {
-                hideWaitingView();
-                Toast.makeText(VectorRoomActivity.this, errorMessage, Toast.LENGTH_SHORT).show();
-            }
+                private void onError(String errorMessage) {
+                    hideWaitingView();
+                    Toast.makeText(VectorRoomActivity.this, errorMessage, Toast.LENGTH_SHORT).show();
+                }
 
-            @Override
-            public void onNetworkError(Exception e) {
-                onError(e.getLocalizedMessage());
-            }
+                @Override
+                public void onNetworkError(Exception e) {
+                    onError(e.getLocalizedMessage());
+                }
 
-            @Override
-            public void onMatrixError(MatrixError e) {
-                onError(e.getLocalizedMessage());
-            }
+                @Override
+                public void onMatrixError(MatrixError e) {
+                    onError(e.getLocalizedMessage());
+                }
 
-            @Override
-            public void onUnexpectedError(Exception e) {
-                onError(e.getLocalizedMessage());
-            }
-        });
+                @Override
+                public void onUnexpectedError(Exception e) {
+                    onError(e.getLocalizedMessage());
+                }
+            });
+        }
     }
 
     /**
@@ -3842,7 +3855,9 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
         }
 
         // Send sticker
-        items.add(DialogListItem.SendSticker.INSTANCE);
+        if (WidgetManagerProvider.INSTANCE.getWidgetManager(this) != null) {
+            items.add(DialogListItem.SendSticker.INSTANCE);
+        }
 
         // Camera
         if (useNativeCamera) {

--- a/vector/src/main/java/im/vector/activity/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/activity/WidgetActivity.kt
@@ -38,6 +38,7 @@ import butterknife.OnClick
 import im.vector.Matrix
 import im.vector.R
 import im.vector.widgets.Widget
+import im.vector.widgets.WidgetManagerProvider
 import im.vector.widgets.WidgetsManager
 import org.matrix.androidsdk.MXSession
 import org.matrix.androidsdk.core.Log
@@ -73,6 +74,7 @@ class WidgetActivity : VectorAppCompatActivity() {
     private var mTokenAlreadyRefreshed = false
     private var mHistoryAlreadyCleared = false
 
+    private lateinit var widgetsManager: WidgetsManager
     /**
      * Widget events listener
      */
@@ -98,6 +100,12 @@ class WidgetActivity : VectorAppCompatActivity() {
 
         if (null == mWidget || null == mWidget!!.url) {
             Log.e(LOG_TAG, "## onCreate() : invalid widget")
+            finish()
+            return
+        }
+
+        widgetsManager = WidgetManagerProvider.getWidgetManager(this) ?: run {
+            Log.e(LOG_TAG, "## onCreate() : No widget manager ")
             finish()
             return
         }
@@ -138,7 +146,7 @@ class WidgetActivity : VectorAppCompatActivity() {
     override fun onResume() {
         super.onResume()
 
-        WidgetsManager.addListener(mWidgetListener)
+        widgetsManager.addListener(mWidgetListener)
 
         mWidgetWebView.let {
             it.resumeTimers()
@@ -156,7 +164,7 @@ class WidgetActivity : VectorAppCompatActivity() {
             it.onPause()
         }
 
-        WidgetsManager.removeListener(mWidgetListener)
+        widgetsManager.removeListener(mWidgetListener)
     }
 
     /* ==========================================================================================
@@ -169,7 +177,7 @@ class WidgetActivity : VectorAppCompatActivity() {
                 .setMessage(R.string.widget_delete_message_confirmation)
                 .setPositiveButton(R.string.remove) { _, _ ->
                     showWaitingView()
-                    WidgetsManager.getSharedInstance().closeWidget(mSession, mRoom, mWidget!!.widgetId, object : ApiCallback<Void> {
+                    widgetsManager.closeWidget(mSession, mRoom, mWidget!!.widgetId, object : ApiCallback<Void> {
                         override fun onSuccess(info: Void?) {
                             hideWaitingView()
                             finish()
@@ -214,7 +222,7 @@ class WidgetActivity : VectorAppCompatActivity() {
      * Refresh the status bar
      */
     private fun refreshStatusBar() {
-        val canCloseWidget = null == WidgetsManager.getSharedInstance().checkWidgetPermission(mSession, mRoom)
+        val canCloseWidget = null == widgetsManager.checkWidgetPermission(mSession, mRoom)
 
         // close widget button
         mCloseWidgetIcon.isInvisible = !canCloseWidget
@@ -273,14 +281,14 @@ class WidgetActivity : VectorAppCompatActivity() {
                     // In case of 403, try to refresh the scalar token
                     if (errorResponse?.statusCode == HttpsURLConnection.HTTP_FORBIDDEN
                             && !mTokenAlreadyRefreshed
-                            && WidgetsManager.isScalarUrl(this@WidgetActivity, mWidget!!.url)) {
+                            && widgetsManager.isScalarUrl(this@WidgetActivity, mWidget!!.url)) {
                         mTokenAlreadyRefreshed = true
                         mIsRefreshingToken = true
 
                         // Hide the webview because it's displaying an error message we try to fix by refreshing the token
                         mWidgetWebView.isVisible = false
 
-                        WidgetsManager.clearScalarToken(this@WidgetActivity, mSession)
+                        widgetsManager.clearScalarToken(this@WidgetActivity, mSession)
                         loadUrl()
                     }
                 }
@@ -320,7 +328,7 @@ class WidgetActivity : VectorAppCompatActivity() {
 
     private fun loadUrl() {
         showWaitingView()
-        WidgetsManager.getFormattedWidgetUrl(this, mWidget!!, object : ApiCallback<String> {
+        widgetsManager.getFormattedWidgetUrl(this, mWidget!!, object : ApiCallback<String> {
             override fun onSuccess(url: String) {
                 mIsRefreshingToken = false
 

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
@@ -645,8 +645,8 @@ class VectorSettingsPreferencesFragment : PreferenceFragmentCompat(), SharedPref
         findPreference(PreferencesManager.SETTINGS_IDENTITY_SERVER_PREFERENCE_KEY)
                 .summary = mSession.homeServerConfig.identityServerUri.toString()
 
-        findPreference(PreferencesManager.SETTINGS_INTEGRATION_SERVER_URL)
-                .summary = PreferencesManager.getIntegrationServerUrl(context)
+        findPreference(PreferencesManager.SETTINGS_INTEGRATION_SERVER_UI_URL)
+                .summary = PreferencesManager.getIntegrationServerUiUrl(context)
 
         // Analytics
 

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.kt
@@ -645,6 +645,9 @@ class VectorSettingsPreferencesFragment : PreferenceFragmentCompat(), SharedPref
         findPreference(PreferencesManager.SETTINGS_IDENTITY_SERVER_PREFERENCE_KEY)
                 .summary = mSession.homeServerConfig.identityServerUri.toString()
 
+        findPreference(PreferencesManager.SETTINGS_INTEGRATION_SERVER_URL)
+                .summary = PreferencesManager.getIntegrationServerUrl(context)
+
         // Analytics
 
         // Analytics tracking management

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -164,7 +164,9 @@ public class PreferencesManager {
     public static final String SETTINGS_USE_RAGE_SHAKE_KEY = "SETTINGS_USE_RAGE_SHAKE_KEY";
 
     //Integrations
-    public static final String SETTINGS_INTEGRATION_SERVER_URL = "SETTINGS_INTEGRATION_SERVER_URL";
+    public static final String SETTINGS_INTEGRATION_SERVER_UI_URL = "SETTINGS_INTEGRATION_SERVER_UI_URL";
+    public static final String SETTINGS_INTEGRATION_SERVER_API_URL = "SETTINGS_INTEGRATION_SERVER_API_URL";
+    public static final String SETTINGS_INTEGRATION_SERVER_JITSI_URL = "SETTINGS_INTEGRATION_SERVER_JITSI_URL";
     public static final String SETTINGS_INTEGRATION_WHITELIST_URL = "SETTINGS_INTEGRATION_WHITELIST_URL";
 
     // other
@@ -272,16 +274,42 @@ public class PreferencesManager {
                 .apply();
     }
 
-    public static String getIntegrationServerUrl(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getString(SETTINGS_INTEGRATION_SERVER_URL,
-                context.getString(R.string.integration_server_url));
+    public static String getIntegrationServerUiUrl(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getString(SETTINGS_INTEGRATION_SERVER_UI_URL,
+                context.getString(R.string.integrations_ui_url));
     }
 
-    public static void setIntegrationServerUrl(Context context, String url) {
-        PreferenceManager.getDefaultSharedPreferences(context)
-                .edit()
-                .putString(SETTINGS_INTEGRATION_SERVER_URL, url)
-                .apply();
+    public static String getIntegrationServerApiUrl(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getString(SETTINGS_INTEGRATION_SERVER_API_URL,
+                context.getString(R.string.integrations_rest_url));
+    }
+
+    public static String getIntegrationServerJitsiUrl(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getString(SETTINGS_INTEGRATION_SERVER_JITSI_URL,
+                context.getString(R.string.integrations_jitsi_widget_url));
+    }
+
+
+    public static void setIntegrationServerUrls(Context context, String uiURl, String apiURl, String jitsyUrl) {
+        if (uiURl != null) {
+            PreferenceManager.getDefaultSharedPreferences(context)
+                    .edit()
+                    .putString(SETTINGS_INTEGRATION_SERVER_UI_URL, uiURl)
+                    .apply();
+        }
+        if (apiURl != null) {
+            PreferenceManager.getDefaultSharedPreferences(context)
+                    .edit()
+                    .putString(SETTINGS_INTEGRATION_SERVER_API_URL, apiURl)
+                    .apply();
+        }
+
+        if (jitsyUrl != null) {
+            PreferenceManager.getDefaultSharedPreferences(context)
+                    .edit()
+                    .putString(SETTINGS_INTEGRATION_SERVER_JITSI_URL, jitsyUrl)
+                    .apply();
+        }
     }
 
     public static List<String> getIntegrationWhiteListedUrl(Context context) {

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -2,6 +2,7 @@
  * Copyright 2016 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
  * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +31,7 @@ import android.text.TextUtils;
 import org.matrix.androidsdk.core.Log;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -161,6 +163,10 @@ public class PreferencesManager {
     public static final String SETTINGS_USE_ANALYTICS_KEY = "SETTINGS_USE_ANALYTICS_KEY";
     public static final String SETTINGS_USE_RAGE_SHAKE_KEY = "SETTINGS_USE_RAGE_SHAKE_KEY";
 
+    //Integrations
+    public static final String SETTINGS_INTEGRATION_SERVER_URL = "SETTINGS_INTEGRATION_SERVER_URL";
+    public static final String SETTINGS_INTEGRATION_WHITELIST_URL = "SETTINGS_INTEGRATION_WHITELIST_URL";
+
     // other
     public static final String SETTINGS_MEDIA_SAVING_PERIOD_KEY = "SETTINGS_MEDIA_SAVING_PERIOD_KEY";
     private static final String SETTINGS_MEDIA_SAVING_PERIOD_SELECTED_KEY = "SETTINGS_MEDIA_SAVING_PERIOD_SELECTED_KEY";
@@ -266,9 +272,29 @@ public class PreferencesManager {
                 .apply();
     }
 
+    public static String getIntegrationServerUrl(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getString(SETTINGS_INTEGRATION_SERVER_URL,
+                context.getString(R.string.integration_server_url));
+    }
+
+    public static void setIntegrationServerUrl(Context context, String url) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putString(SETTINGS_INTEGRATION_SERVER_URL, url)
+                .apply();
+    }
+
+    public static List<String> getIntegrationWhiteListedUrl(Context context) {
+        Set<String> defaultSet = new HashSet<>(Arrays.asList(context.getResources().getStringArray(R.array.integrations_widgets_urls)));
+        Set<String> set = PreferenceManager.getDefaultSharedPreferences(context).getStringSet(SETTINGS_INTEGRATION_WHITELIST_URL, defaultSet);
+        return new ArrayList<>(set);
+    }
+
+
     public static boolean didMigrateToNotificationRework(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(DID_MIGRATE_TO_NOTIFICATION_REWORK, false);
     }
+
     public static void setDidMigrateToNotificationRework(Context context) {
         PreferenceManager.getDefaultSharedPreferences(context)
                 .edit()

--- a/vector/src/main/java/im/vector/util/SlashCommandsParser.java
+++ b/vector/src/main/java/im/vector/util/SlashCommandsParser.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2016 OpenMarket Ltd
  * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +40,7 @@ import im.vector.R;
 import im.vector.VectorApp;
 import im.vector.activity.CommonActivityUtils;
 import im.vector.activity.VectorRoomActivity;
+import im.vector.widgets.WidgetManagerProvider;
 import im.vector.widgets.WidgetsManager;
 
 public class SlashCommandsParser {
@@ -340,9 +342,12 @@ public class SlashCommandsParser {
                 isIRCCmd = true;
                 isIRCCmdValid = true;
 
-                WidgetsManager.clearScalarToken(activity, session);
+                WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(activity);
+                if (wm != null) {
+                    wm.clearScalarToken(activity, session);
+                    Toast.makeText(activity, "Scalar token cleared", Toast.LENGTH_SHORT).show();
+                }
 
-                Toast.makeText(activity, "Scalar token cleared", Toast.LENGTH_SHORT).show();
             }
 
             if (!isIRCCmd) {

--- a/vector/src/main/java/im/vector/view/ActiveWidgetsBanner.java
+++ b/vector/src/main/java/im/vector/view/ActiveWidgetsBanner.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2016 OpenMarket Ltd
  * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +33,7 @@ import java.util.List;
 
 import im.vector.R;
 import im.vector.widgets.Widget;
+import im.vector.widgets.WidgetManagerProvider;
 import im.vector.widgets.WidgetsManager;
 
 /**
@@ -166,8 +168,12 @@ public class ActiveWidgetsBanner extends FrameLayout {
      * Refresh the view visibility
      */
     private void refresh() {
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(getContext());
+        if (wm == null) {
+            return;
+        }
         if ((null != mRoom) && (null != mSession)) {
-            List<Widget> activeWidgets = WidgetsManager.getSharedInstance().getActiveWebviewWidgets(mSession, mRoom);
+            List<Widget> activeWidgets = wm.getActiveWebviewWidgets(mSession, mRoom);
             Widget firstWidget = null;
 
             if ((activeWidgets.size() != mActiveWidgets.size()) || !mActiveWidgets.containsAll(activeWidgets)) {
@@ -193,7 +199,7 @@ public class ActiveWidgetsBanner extends FrameLayout {
             setVisibility((mActiveWidgets.size() > 0) ? View.VISIBLE : View.GONE);
 
             // show the close widget button if the user is allowed to do it
-            mCloseWidgetIcon.setVisibility(((null != firstWidget) && (null == WidgetsManager.getSharedInstance().checkWidgetPermission(mSession, mRoom))) ?
+            mCloseWidgetIcon.setVisibility(((null != firstWidget) && (null == wm.checkWidgetPermission(mSession, mRoom))) ?
                     View.VISIBLE : View.GONE);
         }
     }
@@ -203,13 +209,19 @@ public class ActiveWidgetsBanner extends FrameLayout {
      */
     public void onActivityResume() {
         refresh();
-        WidgetsManager.getSharedInstance().addListener(mWidgetListener);
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(getContext());
+        if (wm != null) {
+            wm.addListener(mWidgetListener);
+        }
     }
 
     /**
      * The parent activity is suspended
      */
     public void onActivityPause() {
-        WidgetsManager.getSharedInstance().removeListener(mWidgetListener);
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(getContext());
+        if (wm != null) {
+            wm.removeListener(mWidgetListener);
+        }
     }
 }

--- a/vector/src/main/java/im/vector/view/VectorOngoingConferenceCallView.java
+++ b/vector/src/main/java/im/vector/view/VectorOngoingConferenceCallView.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2016 OpenMarket Ltd
  * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +46,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import im.vector.R;
 import im.vector.widgets.Widget;
+import im.vector.widgets.WidgetManagerProvider;
 import im.vector.widgets.WidgetsManager;
 
 /**
@@ -239,8 +241,12 @@ public class VectorOngoingConferenceCallView extends RelativeLayout {
      * Refresh the view visibility
      */
     public void refresh() {
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(getContext());
+        if (wm == null) {
+            return;
+        }
         if ((null != mRoom) && (null != mSession)) {
-            List<Widget> mActiveWidgets = WidgetsManager.getSharedInstance().getActiveJitsiWidgets(mSession, mRoom);
+            List<Widget> mActiveWidgets = wm.getActiveJitsiWidgets(mSession, mRoom);
             Widget widget = mActiveWidgets.isEmpty() ? null : mActiveWidgets.get(0);
 
             if (mActiveWidget != widget) {
@@ -258,7 +264,7 @@ public class VectorOngoingConferenceCallView extends RelativeLayout {
             setVisibility(((!MXCallsManager.isCallInProgress(call) && mRoom.isOngoingConferenceCall()) || (null != mActiveWidget)) ? View.VISIBLE : View.GONE);
 
             // show the close widget button if the user is allowed to do it
-            mCloseWidgetIcon.setVisibility(((null != mActiveWidget) && (null == WidgetsManager.getSharedInstance().checkWidgetPermission(mSession, mRoom))) ?
+            mCloseWidgetIcon.setVisibility(((null != mActiveWidget) && (null == wm.checkWidgetPermission(mSession, mRoom))) ?
                     View.VISIBLE : View.GONE);
         }
     }
@@ -272,8 +278,10 @@ public class VectorOngoingConferenceCallView extends RelativeLayout {
         if (null != mSession) {
             mSession.mCallsManager.addListener(mCallsListener);
         }
-
-        WidgetsManager.addListener(mWidgetListener);
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(getContext());
+        if (wm != null) {
+            wm.addListener(mWidgetListener);
+        }
     }
 
     /**
@@ -283,8 +291,10 @@ public class VectorOngoingConferenceCallView extends RelativeLayout {
         if (null != mSession) {
             mSession.mCallsManager.removeListener(mCallsListener);
         }
-
-        WidgetsManager.removeListener(mWidgetListener);
+        WidgetsManager wm = WidgetManagerProvider.INSTANCE.getWidgetManager(getContext());
+        if (wm != null) {
+            wm.removeListener(mWidgetListener);
+        }
     }
 
     /**

--- a/vector/src/main/java/im/vector/widgets/IntegrationManagerConfig.kt
+++ b/vector/src/main/java/im/vector/widgets/IntegrationManagerConfig.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.widgets
+
+/**
+ * Configuration for an integration manager.
+ * By default, it uses URLs defined in the app settings but they can be overidden.
+ */
+data class IntegrationManagerConfig(
+        val uiUrl: String,
+        val apiUrl: String,
+        val jitsiUrl : String,
+        val whiteListedUrls : List<String> = emptyList()
+)
+

--- a/vector/src/main/java/im/vector/widgets/WidgetManagerProvider.kt
+++ b/vector/src/main/java/im/vector/widgets/WidgetManagerProvider.kt
@@ -29,17 +29,22 @@ object WidgetManagerProvider {
         if (widgetsManager != null) {
             return widgetsManager
         }
-        val serverURL = PreferencesManager.getIntegrationServerUrl(context)
-        if (serverURL.isNullOrBlank()) return null
+        val uiURl = PreferencesManager.getIntegrationServerUiUrl(context)
+        val apiURL = PreferencesManager.getIntegrationServerApiUrl(context)
+        val jitsiUrl = PreferencesManager.getIntegrationServerJitsiUrl(context)
+        if (uiURl.isNullOrBlank() || apiURL.isNullOrBlank() || jitsiUrl.isNullOrBlank()) return null
         return try {
-            URL(serverURL)
+            //Very basic validity check (well formed url)
+            URL(uiURl)
+            URL(apiURL)
+            URL(jitsiUrl)
             val defaultWhitelist = ArrayList(PreferencesManager.getIntegrationWhiteListedUrl(context))
-            defaultWhitelist.add(0,"$serverURL/api")
+            defaultWhitelist.add(0,apiURL)
 
             val config = IntegrationManagerConfig(
-                    uiUrl = "$serverURL/",
-                    apiUrl = "$serverURL/api",
-                    jitsiUrl = "$serverURL/api/widgets/jitsi.html",
+                    uiUrl = uiURl,
+                    apiUrl = apiURL,
+                    jitsiUrl = jitsiUrl,
                     whiteListedUrls = defaultWhitelist)
             WidgetsManager(config).also {
                 this.widgetsManager = it

--- a/vector/src/main/java/im/vector/widgets/WidgetManagerProvider.kt
+++ b/vector/src/main/java/im/vector/widgets/WidgetManagerProvider.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.widgets
+
+import android.content.Context
+import im.vector.R
+import im.vector.util.PreferencesManager
+import java.net.MalformedURLException
+import java.net.URL
+
+object WidgetManagerProvider {
+
+    private var widgetsManager: WidgetsManager? = null
+
+    fun getWidgetManager(context: Context): WidgetsManager? {
+        if (widgetsManager != null) {
+            return widgetsManager
+        }
+        val serverURL = PreferencesManager.getIntegrationServerUrl(context)
+        if (serverURL.isNullOrBlank()) return null
+        return try {
+            URL(serverURL)
+            val defaultWhitelist = ArrayList(PreferencesManager.getIntegrationWhiteListedUrl(context))
+            defaultWhitelist.add(0,"$serverURL/api")
+
+            val config = IntegrationManagerConfig(
+                    uiUrl = "$serverURL/",
+                    apiUrl = "$serverURL/api",
+                    jitsiUrl = "$serverURL/api/widgets/jitsi.html",
+                    whiteListedUrls = defaultWhitelist)
+            WidgetsManager(config).also {
+                this.widgetsManager = it
+            }
+        } catch (e: MalformedURLException) {
+            null
+        }
+
+    }
+}

--- a/vector/src/main/java/im/vector/widgets/WidgetsRestClient.java
+++ b/vector/src/main/java/im/vector/widgets/WidgetsRestClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2015 OpenMarket Ltd
  * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +27,6 @@ import org.matrix.androidsdk.rest.callback.RestAdapterCallback;
 
 import java.util.Map;
 
-import im.vector.R;
-
 class WidgetsRestClient extends RestClient<WidgetsApi> {
 
     private static final String API_VERSION = "1.1";
@@ -35,9 +34,9 @@ class WidgetsRestClient extends RestClient<WidgetsApi> {
     /**
      * {@inheritDoc}
      */
-    public WidgetsRestClient(Context context) {
+    public WidgetsRestClient(Context context, IntegrationManagerConfig config) {
         super(new HomeServerConnectionConfig.Builder()
-                        .withHomeServerUri(Uri.parse(context.getString(R.string.integrations_rest_url)))
+                        .withHomeServerUri(Uri.parse(config.getApiUrl()))
                         .build(),
                 WidgetsApi.class,
                 "",
@@ -53,12 +52,7 @@ class WidgetsRestClient extends RestClient<WidgetsApi> {
     public void register(final Map<Object, Object> params, final ApiCallback<Map<String, String>> callback) {
         final String description = "Register";
 
-        mApi.register(params, API_VERSION).enqueue(new RestAdapterCallback<Map<String, String>>(description,
-                mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
-            @Override
-            public void onRetry() {
-                register(params, callback);
-            }
-        }));
+        mApi.register(params, API_VERSION).enqueue(new RestAdapterCallback<>(description,
+                mUnsentEventsManager, callback, () -> register(params, callback)));
     }
 }

--- a/vector/src/main/res/values/config.xml
+++ b/vector/src/main/res/values/config.xml
@@ -14,8 +14,7 @@
     <string name="bug_report_url" translatable="false">https://riot.im/bugreports/submit</string>
 
     <!-- Widget urls -->
-    <string name="integrations_ui_url" translatable="false">"https://scalar.vector.im/"</string>
-    <string name="integrations_rest_url" translatable="false">"https://scalar.vector.im/api"</string>
+    <string name="integration_server_url" translatable="false">"https://scalar.vector.im"</string>
 
     <string-array name="integrations_widgets_urls" translatable="false">
         <item>https://scalar-staging.riot.im/scalar/api</item>

--- a/vector/src/main/res/values/config.xml
+++ b/vector/src/main/res/values/config.xml
@@ -14,7 +14,9 @@
     <string name="bug_report_url" translatable="false">https://riot.im/bugreports/submit</string>
 
     <!-- Widget urls -->
-    <string name="integration_server_url" translatable="false">"https://scalar.vector.im"</string>
+    <string name="integrations_ui_url" translatable="false">"https://scalar.vector.im/"</string>
+    <string name="integrations_rest_url" translatable="false">"https://scalar.vector.im/api"</string>
+    <string name="integrations_jitsi_widget_url" translatable="false">"https://scalar.vector.im/api/widgets/jitsi.html"</string>
 
     <string-array name="integrations_widgets_urls" translatable="false">
         <item>https://scalar-staging.riot.im/scalar/api</item>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -809,6 +809,7 @@
     <string name="settings_logged_in">Logged in as</string>
     <string name="settings_home_server">Home Server</string>
     <string name="settings_identity_server">Identity Server</string>
+    <string name="settings_integration_server">Integration Server</string>
 
     <string name="settings_user_interface">User interface</string>
     <string name="settings_interface_language">Language</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -809,7 +809,7 @@
     <string name="settings_logged_in">Logged in as</string>
     <string name="settings_home_server">Home Server</string>
     <string name="settings_identity_server">Identity Server</string>
-    <string name="settings_integration_server">Integration Server</string>
+    <string name="settings_integration_manager">Integration Manager</string>
 
     <string name="settings_user_interface">User interface</string>
     <string name="settings_interface_language">Language</string>
@@ -1092,6 +1092,7 @@
     <string name="widget_integration_room_not_visible">Room %s is not visible.</string>
     <string name="widget_integration_missing_parameter">A required parameter is missing.</string>
     <string name="widget_integration_invalid_parameter">A parameter is not valid.</string>
+    <string name="widget_integration_no_server">No integration server configured.</string>
     <string name="room_add_matrix_apps">Add Matrix apps</string>
     <string name="settings_labs_native_camera">Use native camera</string>
     <string name="settings_labs_native_camera_summary">Start the system camera instead of the custom camera screen.</string>
@@ -1628,5 +1629,6 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
     <string name="labs_swipe_to_reply_in_timeline">Enable swipe to reply in timeline</string>
 
     <string name="link_copied_to_clipboard">Link copied to clipboard</string>
+
 
 </resources>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -424,6 +424,12 @@
             android:title="@string/settings_identity_server"
             tools:summary="@string/default_identity_server_url" />
 
+
+        <im.vector.preference.VectorPreference
+            android:key="SETTINGS_INTEGRATION_SERVER_URL"
+            android:defaultValue="@string/integration_server_url"
+            android:title="@string/settings_integration_server"/>
+
     </im.vector.preference.VectorPreferenceCategory>
 
     <im.vector.preference.VectorPreferenceDivider />

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -426,8 +426,8 @@
 
 
         <im.vector.preference.VectorPreference
-            android:key="SETTINGS_INTEGRATION_SERVER_URL"
-            android:defaultValue="@string/integration_server_url"
+            android:key="SETTINGS_INTEGRATION_SERVER_UI_URL"
+            android:defaultValue="@string/integrations_ui_url"
             android:title="@string/settings_integration_server"/>
 
     </im.vector.preference.VectorPreferenceCategory>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -428,7 +428,7 @@
         <im.vector.preference.VectorPreference
             android:key="SETTINGS_INTEGRATION_SERVER_UI_URL"
             android:defaultValue="@string/integrations_ui_url"
-            android:title="@string/settings_integration_server"/>
+            android:title="@string/settings_integration_manager"/>
 
     </im.vector.preference.VectorPreferenceCategory>
 


### PR DESCRIPTION
Fixes #3224 

Make widget/integration manager optional.
Integration manager is read from preferences with default values to new vector integration server.
Integration (Matrix app / stickers) ui elements are removed when no integration manager is defined

<img width="244" alt="image" src="https://user-images.githubusercontent.com/9841565/62195819-11a7bc00-b37d-11e9-8c70-34ff86e0f752.png">

<img width="242" alt="image" src="https://user-images.githubusercontent.com/9841565/62195303-03a56b80-b37c-11e9-8cdd-c5b31f91f393.png">
