### PR TITLE
Try to fix issue 2453

### DIFF
--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -833,6 +833,9 @@ public class EventStreamService extends Service {
                 || (mForegroundNotificationState == ForegroundNotificationState.CALL_IN_PROGRESS)) {
             Log.i(LOG_TAG, "## refreshForegroundNotification : does nothing as there is a pending call");
             return;
+        } else {
+            // cancel call in progress notifications if there's no pending call.
+            hideCallNotifications();
         }
 
         // GA issue


### PR DESCRIPTION
Will this fix #2453 ?
I didn't have build environment at hand for testing and not quite familiar with this repository. So I just made those small changes based on my observation:

I found "refreshForegroundNotification" seems to be a function called when synchronising from homeserver. And since mForegroundNotificationState != INCOMING_CALL or CALL_IN_PROGRESS, I just call hideCallNotifications() to remove the notification.

Sorry for not digging deeper into the source code. This bug is really very annoying, please help me to verify whether this fix works. Thanks a lot.