### PR TITLE
Feature/fix infinite restart expired cred

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Other changes:
 
 Bugfix 🐛:
  - Crash / potential NPE after logout (#3367)
+ - Fix infinite restart loop after token expiration (#3249)
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -316,38 +316,33 @@ public class CommonActivityUtils {
     private static boolean isRecoveringFromInvalidatedToken = false;
 
     public static void recoverInvalidatedToken() {
+        Log.e(LOG_TAG, "## recoverInvalidatedToken: Start Recover ");
 
         if (isRecoveringFromInvalidatedToken) {
             //ignore, we are doing it
+            Log.e(LOG_TAG, "## recoverInvalidatedToken: ignore, we are doing it");
             return;
         }
         isRecoveringFromInvalidatedToken = true;
         Context context = VectorApp.getCurrentActivity() != null ? VectorApp.getCurrentActivity() : VectorApp.getInstance();
 
         try {
+
+            // Clear the credentials
+            Matrix.getInstance(context).getLoginStorage().clear() ;
+
+
             VectorApp.getInstance().getNotificationDrawerManager().clearAllEvents();
-            EventStreamServiceX.Companion.onLogout(context);
-            // stopEventStream(context);
+            EventStreamServiceX.Companion.onApplicationStopped(context);
 
             BadgeProxy.INSTANCE.updateBadgeCount(context, 0);
 
             MXSession session = Matrix.getInstance(context).getDefaultSession();
-
-            // Publish to the server that we're now offline
-            MyPresenceManager.getInstance(context, session).advertiseOffline();
-            MyPresenceManager.remove(session);
-
             // clear the preferences
             PreferencesManager.clearPreferences(context);
 
-            // reset the FCM
-            Matrix.getInstance(context).getPushManager().resetFCMRegistration();
-
             // clear the preferences
             Matrix.getInstance(context).getPushManager().clearPreferences();
-
-            // Clear the credentials
-            Matrix.getInstance(context).getLoginStorage().clear();
 
             // clear the tmp store list
             Matrix.getInstance(context).clearTmpStoresList();
@@ -358,20 +353,11 @@ public class CommonActivityUtils {
 
             MXMediaCache.clearThumbnailsCache(context);
 
-            Matrix.getInstance(context).clearSessions(context, true, new SimpleApiCallback<Void>() {
-
-                @Override
-                public void onSuccess(Void info) {
-
-                }
-            });
-            session.clear(context);
         } catch (Exception e) {
             Log.e(LOG_TAG, "## recoverInvalidatedToken: Error while cleaning: ", e);
         } finally {
-            // go to login page
-            CommonActivityUtils.restartApp(context, true);
             isRecoveringFromInvalidatedToken = false;
+            CommonActivityUtils.restartApp(context, true);
         }
     }
 

--- a/vector/src/main/java/im/vector/store/LoginStorage.java
+++ b/vector/src/main/java/im/vector/store/LoginStorage.java
@@ -199,6 +199,6 @@ public class LoginStorage {
         SharedPreferences prefs = mContext.getSharedPreferences(PREFS_LOGIN, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         editor.remove(PREFS_KEY_CONNECTION_CONFIGS);
-        editor.apply();
+        editor.commit();
     }
 }

--- a/vector/src/main/java/im/vector/store/LoginStorage.java
+++ b/vector/src/main/java/im/vector/store/LoginStorage.java
@@ -199,6 +199,7 @@ public class LoginStorage {
         SharedPreferences prefs = mContext.getSharedPreferences(PREFS_LOGIN, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         editor.remove(PREFS_KEY_CONNECTION_CONFIGS);
+        //Need to commit now because called before forcing an app restart
         editor.commit();
     }
 }


### PR DESCRIPTION
Fixes #3249 
Tested against config with SSO and 3mn expiration.

Riot handles token expiration by 'restarting the app' (exit 0); The issue is that the credentials were cleared from the preferences using apply instead of commit (thus never serialized due to the 'restart')