### PR TITLE
Support SSO with Firefox accounts (#3337)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Features ✨:
  -
 
 Improvements 🙌:
- -
+ - Support SSO with Firefox accounts (#3337)
 
 Other changes:
  -

--- a/vector/src/main/java/im/vector/activity/FallbackAuthenticationActivity.kt
+++ b/vector/src/main/java/im/vector/activity/FallbackAuthenticationActivity.kt
@@ -65,6 +65,11 @@ class FallbackAuthenticationActivity : VectorAppCompatActivity() {
         mMode = intent.getIntExtra(EXTRA_IN_MODE, MODE_LOGIN)
 
         mWebView.settings.javaScriptEnabled = true
+
+        // Enable local storage to support SSO with Firefox accounts
+        mWebView.settings.domStorageEnabled = true
+        mWebView.settings.databaseEnabled = true
+
         // Due to https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html, we hack
         // the user agent to bypass the limitation of Google, as a quick fix (a proper solution will be to use the SSO SDK)
         mWebView.settings.userAgentString = "Mozilla/5.0 Google"


### PR DESCRIPTION
Fixes #3337 

Tested on API 16, but due to TLS limitation, SSO is not allowed on API16