### PR TITLE
Fix issue in activity_vector_group_details.xml

### DIFF
--- a/vector/src/main/res/layout/activity_vector_group_details.xml
+++ b/vector/src/main/res/layout/activity_vector_group_details.xml
@@ -44,6 +44,7 @@
         android:background="@android:color/transparent"
         android:indeterminate="true"
         android:indeterminateTint="@color/tab_groups_secondary"
+        android:indeterminateTintMode="src_in"
         android:visibility="visible" />
 
     <im.vector.view.VectorViewPager


### PR DESCRIPTION
Hi,

I have found there is a compatibility issue in activity_vector_group_details.xml. You forget to add `android:indeterminateTintMode="src_in"`, which can cause different ProgressBar color in API Level <= 22. This pull request help you fix this problem.

Thanks and wish the information is useful for you.
